### PR TITLE
Ticket 194 - periodic sync with discord threads

### DIFF
--- a/cog_scn.py
+++ b/cog_scn.py
@@ -81,7 +81,7 @@ class SCNCog(commands.Cog):
         # get all threads
         for guild in self.bot.guilds:
             for thread in guild.threads:
-                log.debug(f"THREAD: guild:{guild}, thread:{thread}")
+                #log.debug(f"THREAD: guild:{guild}, thread:{thread}")
                 # sync each thread, 
                 ticket = await self.sync_thread(thread)
                 if ticket:
@@ -89,6 +89,7 @@ class SCNCog(commands.Cog):
                     log.debug(f"SYNC: thread:{thread.name} with ticket {ticket.id}")
                 else:
                     log.debug(f"no ticket found for {thread.name}")
+
 
     @scn.command()
     async def sync(self, ctx:discord.ApplicationContext):

--- a/cog_tickets.py
+++ b/cog_tickets.py
@@ -181,7 +181,7 @@ class TicketsCog(commands.Cog):
                 await thread.send(msg)
 
             # TODO format command for single ticket
-            await ctx.respond(f"Created new thread for {ticket.id}: {thread}") # todo add some fancy formatting
+            await ctx.send(f"Created new thread for {ticket.id}: {thread}") # todo add some fancy formatting
         else:
             await ctx.respond(f"ERROR: Unkown ticket ID: {ticket_id}") # todo add some fancy formatting
             

--- a/cog_tickets.py
+++ b/cog_tickets.py
@@ -151,14 +151,14 @@ class TicketsCog(commands.Cog):
     async def create_thread(self, ticket, ctx):
         log.info(f"creating a new thread for ticket #{ticket.id} in channel: {ctx.channel}")
         name = f"Ticket #{ticket.id}"
-        msg_txt = f"Syncing ticket {self.redmine.get_field(ticket, 'url')} to this thread."
+        msg_txt = f"Syncing ticket {self.redmine.get_field(ticket, 'url')} to new thread '{name}'"
         message = await ctx.send(msg_txt)
         return await message.create_thread(name=name)
         
 
     @commands.slash_command(description="Create a Discord thread for the specified ticket") 
     @option("ticket_id", description="ID of tick to create thread for")
-    async def thread(self, ctx: discord.ApplicationContext, ticket_id:int):
+    async def thread_ticket(self, ctx: discord.ApplicationContext, ticket_id:int):
         ticket = self.redmine.get_ticket(ticket_id)
         if ticket:
             # create the thread...
@@ -171,14 +171,14 @@ class TicketsCog(commands.Cog):
             self.redmine.enable_discord_sync(ticket.id, user, note)
 
             # REFACTOR: We know the thread has just been created, just get messages-since in redmine.
-            notes = self.redmine.get_notes_since(ticket.id, None) # None since date for all.
-            log.info(f"syncing {len(notes)} notes from {ticket.id} --> {thread.name}")
+            #notes = self.redmine.get_notes_since(ticket.id, None) # None since date for all.
+            #log.info(f"syncing {len(notes)} notes from {ticket.id} --> {thread.name}")
 
             # NOTE: There doesn't seem to be a method for acting as a specific user, 
             # so adding user and date to the sync note.
-            for note in notes:
-                msg = f"> **{note.user.name}** at *{note.created_on}*\n> {note.notes}\n\n"
-                await thread.send(msg)
+            #for note in notes:
+            #    msg = f"> **{note.user.name}** at *{note.created_on}*\n> {note.notes}\n\n"
+            #    await thread.send(msg)
 
             # TODO format command for single ticket
             await ctx.send(f"Created new thread for {ticket.id}: {thread}") # todo add some fancy formatting

--- a/cog_tickets.py
+++ b/cog_tickets.py
@@ -153,7 +153,8 @@ class TicketsCog(commands.Cog):
         name = f"Ticket #{ticket.id}"
         msg_txt = f"Syncing ticket {self.redmine.get_field(ticket, 'url')} to new thread '{name}'"
         message = await ctx.send(msg_txt)
-        return await message.create_thread(name=name)
+        thread = await message.create_thread(name=name)
+        return thread
         
 
     @commands.slash_command(description="Create a Discord thread for the specified ticket") 

--- a/cog_tickets.py
+++ b/cog_tickets.py
@@ -177,7 +177,7 @@ class TicketsCog(commands.Cog):
             # NOTE: There doesn't seem to be a method for acting as a specific user, 
             # so adding user and date to the sync note.
             for note in notes:
-                msg = f"> **{note.user.name}** at *{note.created_on}*\n\n{note.notes}\n"
+                msg = f"> **{note.user.name}** at *{note.created_on}*\n> {note.notes}\n\n"
                 await thread.send(msg)
 
             # TODO format command for single ticket

--- a/cog_tickets.py
+++ b/cog_tickets.py
@@ -150,9 +150,11 @@ class TicketsCog(commands.Cog):
 
     async def create_thread(self, ticket, ctx):
         log.info(f"creating a new thread for ticket #{ticket.id} in channel: {ctx.channel}")
-        name = f"Ticket #{ticket.id}: {ticket.subject}"
-        return await ctx.channel.create_thread(name=name)
-
+        name = f"Ticket #{ticket.id}"
+        msg_txt = f"Syncing ticket {self.redmine.get_field(ticket, 'url')} to this thread."
+        message = await ctx.send(msg_txt)
+        return await message.create_thread(name=name)
+        
 
     @commands.slash_command(description="Create a Discord thread for the specified ticket") 
     @option("ticket_id", description="ID of tick to create thread for")
@@ -168,14 +170,21 @@ class TicketsCog(commands.Cog):
             user = self.redmine.find_discord_user(ctx.user.name)
             self.redmine.enable_discord_sync(ticket.id, user, note)
 
-            # sync the ticket, so everything is up to date
-            await self.bot.synchronize_ticket(ticket, thread, ctx)
+            # REFACTOR: We know the thread has just been created, just get messages-since in redmine.
+            notes = self.redmine.get_notes_since(ticket.id, None) # None since date for all.
+            log.info(f"syncing {len(notes)} notes from {ticket.id} --> {thread.name}")
+
+            # NOTE: There doesn't seem to be a method for acting as a specific user, 
+            # so adding user and date to the sync note.
+            for note in notes:
+                msg = f"> **{note.user.name}** at *{note.created_on}*\n\n{note.notes}\n"
+                await thread.send(msg)
 
             # TODO format command for single ticket
             await ctx.respond(f"Created new thread for {ticket.id}: {thread}") # todo add some fancy formatting
         else:
             await ctx.respond(f"ERROR: Unkown ticket ID: {ticket_id}") # todo add some fancy formatting
-
+            
 
     ### formatting ###
 

--- a/netbot.py
+++ b/netbot.py
@@ -143,9 +143,9 @@ class NetBot(commands.Bot):
         if isinstance(error, commands.CommandOnCooldown):
             await ctx.respond("This command is currently on cooldown!")
         else:
-            log.error(f"{error.__cause__}", exc_info=True)
+            log.error(f"{error}", exc_info=True)
             #raise error  # Here we raise other errors to ensure they aren't ignored
-            await ctx.respond(f"{error.__cause__}")
+            await ctx.respond(f"{error}")
 
 
 def main():

--- a/netbot.py
+++ b/netbot.py
@@ -65,7 +65,7 @@ class NetBot(commands.Bot):
         
 
     def parse_thread_title(self, title: str) -> int:
-        match = re.match(r'^Ticket #(\d+):', title)
+        match = re.match(r'^Ticket #(\d+)', title)
         if match:
             return int(match.group(1))
 

--- a/netbot.py
+++ b/netbot.py
@@ -55,6 +55,7 @@ class NetBot(commands.Bot):
 
     async def on_ready(self):
         log.info(f"Logged in as {self.user} (ID: {self.user.id})")
+        log.debug(f"bot: {self}, guilds: {self.guilds}")
         
     async def on_guild_join(self, guild):
         log.info(f"Joined guild: {guild}, id={guild.id}")
@@ -70,16 +71,17 @@ class NetBot(commands.Bot):
             return int(match.group(1))
 
 
-    async def on_message(self, message: discord.Message):
+    # disabled for now... conflicting with the scheduled sync process
+    #async def on_message(self, message: discord.Message):
         # Make sure we won't be replying to ourselves.
         # if message.author.id == bot.user.id:
         #    return
-        if isinstance(message.channel, discord.Thread):
+    #    if isinstance(message.channel, discord.Thread):
             # get the ticket id from the thread name
-            ticket_id = self.parse_thread_title(message.channel.name)
+    #        ticket_id = self.parse_thread_title(message.channel.name)
             
-            if ticket_id:
-                await self.sync_new_message(ticket_id, message)
+    #        if ticket_id:
+    #            await self.sync_new_message(ticket_id, message)
             # else just a normal thread, do nothing
 
 
@@ -134,10 +136,10 @@ class NetBot(commands.Bot):
             log.debug(f"No new discord messages found since {last_sync}")
 
         # update the SYNC timestamp
-        self.redmine.update_syncdata(ticket.id, timestamp)
+        self.redmine.update_syncdata(ticket.id, dt.datetime.now(dt.timezone.utc)) # fresh timestamp, instead of 'timestamp'
         log.info(f"completed sync for {ticket.id} <--> {thread.name}")
         
-    async def xxx_on_application_command_error(self, ctx: discord.ApplicationContext, error: discord.DiscordException):
+    async def on_application_command_error(self, ctx: discord.ApplicationContext, error: discord.DiscordException):
         """Bot-level error handler"""
         if isinstance(error, commands.CommandOnCooldown):
             await ctx.respond("This command is currently on cooldown!")

--- a/netbot.py
+++ b/netbot.py
@@ -53,16 +53,9 @@ class NetBot(commands.Bot):
         log.info(f"starting {self}")
         super().run(os.getenv('DISCORD_TOKEN'))
 
-    async def on_ready(self):
-        log.info(f"Logged in as {self.user} (ID: {self.user.id})")
-        log.debug(f"bot: {self}, guilds: {self.guilds}")
-        
-    async def on_guild_join(self, guild):
-        log.info(f"Joined guild: {guild}, id={guild.id}")
-
-    async def on_thread_join(self, thread):
-        await thread.join()
-        log.info(f"Joined thread: {thread}")
+    #async def on_ready(self):
+    #    log.info(f"Logged in as {self.user} (ID: {self.user.id})")
+    #    log.debug(f"bot: {self}, guilds: {self.guilds}")  
         
 
     def parse_thread_title(self, title: str) -> int:
@@ -71,6 +64,7 @@ class NetBot(commands.Bot):
             return int(match.group(1))
 
 
+    """
     # disabled for now... conflicting with the scheduled sync process
     #async def on_message(self, message: discord.Message):
         # Make sure we won't be replying to ourselves.
@@ -84,7 +78,6 @@ class NetBot(commands.Bot):
     #            await self.sync_new_message(ticket_id, message)
             # else just a normal thread, do nothing
 
-
     async def sync_new_message(self, ticket_id: int, message: discord.Message):
         # ticket = redmine.get_ticket(ticket_id, include_journals=True)
         # create a note with translated discord user id with the update (or one big one?)
@@ -97,9 +90,14 @@ class NetBot(commands.Bot):
         else:
             log.warning(
                 f"sync_new_message - unknown discord user: {message.author.name}, skipping message")
-
-
-    async def synchronize_ticket(self, ticket, thread):
+    """
+    
+    """
+    Synchronize a ticket to a thread
+    """
+    async def synchronize_ticket(self, ticket, thread:discord.Thread):
+        log.debug(f"ticket: {ticket.id}, thread: {thread}")
+        
         # start of the process, will become "last update"
         timestamp = dt.datetime.now(dt.timezone.utc)  # UTC
         
@@ -120,6 +118,7 @@ class NetBot(commands.Bot):
         # see https://docs.pycord.dev/en/stable/api/models.html#discord.Thread.history
         log.debug(f"calling history with thread={thread}, after={last_sync}")
         #messages = await thread.history(after=last_sync, oldest_first=True).flatten()
+        #for message in messages:
         async for message in thread.history(after=last_sync, oldest_first=True):
             # ignore bot messages!
             if message.author.id != self.user.id:

--- a/netbot.py
+++ b/netbot.py
@@ -15,19 +15,18 @@ from discord.ext import commands
 
 
 def setup_logging():
-    logging.basicConfig(level=logging.DEBUG,
-                        format="{asctime} {levelname:<8s} {name:<16} {message}", style='{')
-
+    logging.basicConfig(level=logging.WARNING, format="{asctime} {levelname:<8s} {name:<16} {message}", style='{')
     logging.getLogger("discord.gateway").setLevel(logging.WARNING)
-    logging.getLogger("discord.http").setLevel(logging.INFO)
-    logging.getLogger("urllib3.connectionpool").setLevel(logging.INFO)
-    logging.getLogger("discord.client").setLevel(logging.INFO)
-    logging.getLogger("discord.webhook.async_").setLevel(logging.INFO)
+    logging.getLogger("discord.http").setLevel(logging.WARNING)
+    logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)
+    logging.getLogger("discord.client").setLevel(logging.WARNING)
+    logging.getLogger("discord.webhook.async_").setLevel(logging.WARNING)
 
 
 log = logging.getLogger(__name__)
 
-log.info('initializing bot')
+
+log.info('initializing netbot')
 
 class NetBot(commands.Bot):
     def __init__(self, redmine: redmine.Client):

--- a/redmine.py
+++ b/redmine.py
@@ -213,12 +213,12 @@ class Client(): ## redmine.Client()
         else:
             return None
         
-    def find_discord_user(self, user_id):
-        if user_id == None:
+    def find_discord_user(self, discord_user_id:str):
+        if discord_user_id == None:
             return None
         
-        if user_id in self.discord_users:
-            id = self.discord_users[user_id]
+        if discord_user_id in self.discord_users:
+            id = self.discord_users[discord_user_id]
             return self.user_ids[id]
         else:
             return None

--- a/redmine.py
+++ b/redmine.py
@@ -676,9 +676,8 @@ class Client(): ## redmine.Client()
                         timestr = ticket.custom_fields[1].value 
                         return dt.datetime.fromisoformat(timestr) ### UTC
                     except Exception as e:
-                        log.debug(f"sync tag not set, using epoch")
-                        # note to self: this might be too long ago
-                        return dt.datetime.fromtimestamp(0).astimezone(dt.timezone.utc)
+                        log.debug(f"sync tag not set")
+                        return None
         except AttributeError:
             return "" # or None?
     

--- a/redmine.py
+++ b/redmine.py
@@ -438,7 +438,7 @@ class Client(): ## redmine.Client()
 
         return notes
     
-
+    """
     def discord_tickets(self):
         # todo: check updated field and track what's changed
         threaded_issue_query = "/issues.json?status_id=open&cf_1=1&sort=updated_on:desc"
@@ -449,6 +449,7 @@ class Client(): ## redmine.Client()
         else:
             log.info(f"No open tickets found for: {response.request.url}")
             return None
+    """
 
     def enable_discord_sync(self, ticket_id, user, note):
         fields = {
@@ -482,6 +483,7 @@ class Client(): ## redmine.Client()
         }
         self.update_user(user, fields)
 
+    """ not used
     def join_project(self, username, project:str):
         # look up user ID
         user = self.find_user(username)
@@ -510,7 +512,7 @@ class Client(): ## redmine.Client()
         else:
             resp = json.loads(r.text, object_hook=lambda x: SimpleNamespace(**x))
             log.error(f"Error joining group: {resp.errors}, status={r.status_code}: {r.request.url}, data={data}")
-            
+    """
 
     def join_team(self, username, teamname:str):
         # look up user ID

--- a/redmine.py
+++ b/redmine.py
@@ -677,6 +677,7 @@ class Client(): ## redmine.Client()
                         return dt.datetime.fromisoformat(timestr) ### UTC
                     except Exception as e:
                         log.debug(f"sync tag not set, using epoch")
+                        # note to self: this might be too long ago
                         return dt.datetime.fromtimestamp(0).astimezone(dt.timezone.utc)
         except AttributeError:
             return "" # or None?

--- a/test_cog_scn.py
+++ b/test_cog_scn.py
@@ -16,7 +16,7 @@ from netbot import NetBot
 import test_utils
 
 #logging.basicConfig(level=logging.INFO)
-logging.basicConfig(level=logging.ERROR, 
+logging.basicConfig(level=logging.DEBUG, 
                     format="{asctime} {levelname:<8s} {name:<16} {message}", style='{')
 logging.getLogger("urllib3.connectionpool").setLevel(logging.INFO)
 logging.getLogger("asyncio").setLevel(logging.ERROR)
@@ -33,7 +33,7 @@ class TestSCNCog(test_utils.BotTestCase):
         
     def setUp(self):
         super().setUp()
-        
+        self.bot = NetBot(self.redmine)
         self.bot.load_extension("cog_scn")
         self.cog = self.bot.cogs["SCNCog"] # Note class name, note filename.
         

--- a/test_cog_scn.py
+++ b/test_cog_scn.py
@@ -16,10 +16,10 @@ from netbot import NetBot
 import test_utils
 
 #logging.basicConfig(level=logging.INFO)
-logging.basicConfig(level=logging.DEBUG, 
-                    format="{asctime} {levelname:<8s} {name:<16} {message}", style='{')
-logging.getLogger("urllib3.connectionpool").setLevel(logging.INFO)
-logging.getLogger("asyncio").setLevel(logging.ERROR)
+#logging.basicConfig(level=logging.DEBUG, 
+#                    format="{asctime} {levelname:<8s} {name:<16} {message}", style='{')
+#logging.getLogger("urllib3.connectionpool").setLevel(logging.INFO)
+#logging.getLogger("asyncio").setLevel(logging.ERROR)
 
 log = logging.getLogger(__name__)
 

--- a/test_cog_scn.py
+++ b/test_cog_scn.py
@@ -93,11 +93,11 @@ class TestSCNCog(test_utils.BotTestCase):
         
         ctx = self.build_context()
         ctx.channel = unittest.mock.AsyncMock(discord.Thread)
-        ctx.channel.name = f"Ticket #{test_ticket}: Search for subject match in email threading"
+        ctx.channel.name = f"Ticket #{test_ticket}"
         ctx.channel.id = self.tag
         
         await self.cog.sync(ctx)
-        ctx.respond.assert_called_with(f"SYNC ticket {test_ticket} to thread id: {self.tag} complete")
+        ctx.respond.assert_called_with(f"SYNC ticket {test_ticket} to thread: {ctx.channel.name} complete")
         # check for actual changes! updated timestamp!
 
 

--- a/test_cog_tickets.py
+++ b/test_cog_tickets.py
@@ -16,9 +16,9 @@ import test_utils
 import datetime as dt
 
 
-logging.basicConfig(level=logging.DEBUG, format="{asctime} {levelname:<8s} {name:<16} {message}", style='{')
-logging.getLogger("urllib3.connectionpool").setLevel(logging.INFO)
-logging.getLogger("asyncio").setLevel(logging.ERROR)
+#logging.basicConfig(level=logging.DEBUG, format="{asctime} {levelname:<8s} {name:<16} {message}", style='{')
+#logging.getLogger("urllib3.connectionpool").setLevel(logging.INFO)
+#logging.getLogger("asyncio").setLevel(logging.ERROR)
 
 
 log = logging.getLogger(__name__)

--- a/test_cog_tickets.py
+++ b/test_cog_tickets.py
@@ -15,12 +15,11 @@ import discord
 import test_utils
 import datetime as dt
 
-#logging.basicConfig(level=logging.DEBUG)
 
-logging.basicConfig(level=logging.DEBUG, 
-                    format="{asctime} {levelname:<8s} {name:<16} {message}", style='{')
+logging.basicConfig(level=logging.DEBUG, format="{asctime} {levelname:<8s} {name:<16} {message}", style='{')
 logging.getLogger("urllib3.connectionpool").setLevel(logging.INFO)
 logging.getLogger("asyncio").setLevel(logging.ERROR)
+
 
 log = logging.getLogger(__name__)
 
@@ -99,7 +98,6 @@ class TestTicketsCog(test_utils.BotTestCase):
         self.assertIsNone(self.redmine.get_ticket(int(ticket_id)))
 
     # create thread/sync 
-    @unittest.skip # until sync is working
     async def test_thread_sync(self):
         timestamp = dt.datetime.now().astimezone(dt.timezone.utc).replace(microsecond=0) # strip microseconds
 
@@ -107,47 +105,41 @@ class TestTicketsCog(test_utils.BotTestCase):
         subject = f"Test Thread Ticket {self.tag}"
         text = f"This is a test thread ticket tagged with {self.tag}"
         note = f"This is a test note tagged with {self.tag}"
-        #old_message = f"This is a sync message with {self.tag}"
+        old_message = f"This is a sync message with {self.tag}"
 
         ticket = self.redmine.create_ticket(self.user, subject, text)
         self.redmine.append_message(ticket.id, self.user.login, note)
 
         # thread the ticket using 
         ctx = self.build_context()
-        ctx.channel = unittest.mock.AsyncMock(discord.Thread)
+        ctx.channel = unittest.mock.AsyncMock(discord.TextChannel)
         ctx.channel.name = f"Test Channel {self.tag}"
-        ctx.channel.id = self.tag
+        #ctx.channel.id = self.tag
+        
         thread = unittest.mock.AsyncMock(discord.Thread)
-        # setup history with a message from the user - disabled while I work out the history mock.
-        #member = unittest.mock.AsyncMock(discord.Member)
-        #member.name=self.discord_user
-        #message = unittest.mock.AsyncMock(discord.Message)
-        #message.channel = thread
-        #message.content=old_message
-        #message.author=member
+        thread.name = f"Ticket #{ticket.id}"
+        
+        member = unittest.mock.AsyncMock(discord.Member)
+        member.name=self.discord_user
+        
+        message = unittest.mock.AsyncMock(discord.Message)
+        message.channel = ctx.channel
+        message.content = old_message
+        message.author = member
+        message.create_thread = unittest.mock.AsyncMock(return_value=thread)
+        
+        # TODO setup history with a message from the user - disabled while I work out the history mock.
         #thread.history = unittest.mock.AsyncMock(name="history")
         #thread.history.flatten = unittest.mock.AsyncMock(name="flatten", return_value=[message])
-        ctx.channel.create_thread = unittest.mock.AsyncMock(name="create_thread", return_value=thread)
         
-        await self.cog.thread(ctx, ticket.id)
-        response = ctx.respond.call_args.args[0]
-        thread_response = str(ctx.channel.create_thread.call_args) # hacky
-        log.info(f"#### response args: {ctx.channel.create_thread.call_args}")
+        ctx.send = unittest.mock.AsyncMock(return_value=message)
+        
+        await self.cog.thread_ticket(ctx, ticket.id)
+        
+        response = ctx.send.call_args.args[0]
+        thread_response = str(message.create_thread.call_args) # FIXME
         self.assertIn(str(ticket.id), response)
         self.assertIn(str(ticket.id), thread_response)
-        self.assertIn(self.tag, thread_response)
-
-        # test note appended to thread
-        #log.info(f"#### send args: {thread.send.call_args}")
-        send_args = str(thread.send.call_args) # hacky
-        # call('> **test-s5xyrj Testy** at *2023-12-20T01:28:32Z*\n\nThis is a test note tagged with s5xyrj\n')
-        self.assertIn(self.fullName, send_args)
-        self.assertIn(note, send_args)
-        
-        # test redmine syncdata
-        ticket = self.redmine.get_ticket(ticket.id)
-        last_update = self.redmine.get_field(ticket, "sync")
-        self.assertLessEqual(timestamp, last_update) # hack for TCs that complete in the same second
         
         # delete the ticket
         self.redmine.remove_ticket(ticket.id)

--- a/test_cog_tickets.py
+++ b/test_cog_tickets.py
@@ -99,6 +99,7 @@ class TestTicketsCog(test_utils.BotTestCase):
         self.assertIsNone(self.redmine.get_ticket(int(ticket_id)))
 
     # create thread/sync 
+    @unittest.skip # until sync is working
     async def test_thread_sync(self):
         timestamp = dt.datetime.now().astimezone(dt.timezone.utc).replace(microsecond=0) # strip microseconds
 
@@ -131,7 +132,7 @@ class TestTicketsCog(test_utils.BotTestCase):
         await self.cog.thread(ctx, ticket.id)
         response = ctx.respond.call_args.args[0]
         thread_response = str(ctx.channel.create_thread.call_args) # hacky
-        #log.info(f"#### response args: {ctx.channel.create_thread.call_args}")
+        log.info(f"#### response args: {ctx.channel.create_thread.call_args}")
         self.assertIn(str(ticket.id), response)
         self.assertIn(str(ticket.id), thread_response)
         self.assertIn(self.tag, thread_response)

--- a/test_cog_tickets.py
+++ b/test_cog_tickets.py
@@ -30,7 +30,7 @@ class TestTicketsCog(test_utils.BotTestCase):
         
     def setUp(self):
         super().setUp()
-
+        self.bot = NetBot(self.redmine)
         self.bot.load_extension("cog_tickets")
         self.cog = self.bot.cogs["TicketsCog"] # Note class name, note filename.
     

--- a/test_imap.py
+++ b/test_imap.py
@@ -23,7 +23,6 @@ log = logging.getLogger(__name__)
 class TestMessages(unittest.TestCase):
     
     def setUp(self):
-        #load_dotenv()
         self.redmine = redmine.Client()
         self.imap = imap.Client()
         
@@ -60,9 +59,7 @@ class TestMessages(unittest.TestCase):
         self.assertEqual(addr, "freddy@example.com")
 
     # disabled so I don't flood the system with files
-    @unittest.skip
     def test_upload(self):
-
         with open("test/message-161.eml", 'rb') as file:
             message = self.imap.parse_message(file.read())
             #print(message)

--- a/test_imap.py
+++ b/test_imap.py
@@ -13,8 +13,8 @@ import test_utils
 
 
 #logging.basicConfig(level=logging.DEBUG)
-logging.basicConfig(level=logging.DEBUG, format="{asctime} {levelname:<8s} {name:<16} {message}", style='{')
-logging.getLogger("urllib3.connectionpool").setLevel(logging.INFO)
+#logging.basicConfig(level=logging.DEBUG, format="{asctime} {levelname:<8s} {name:<16} {message}", style='{')
+#logging.getLogger("urllib3.connectionpool").setLevel(logging.INFO)
 
 log = logging.getLogger(__name__)
 

--- a/test_imap.py
+++ b/test_imap.py
@@ -106,6 +106,7 @@ class TestMessages(unittest.TestCase):
         
         self.redmine.reindex_users()
         user = self.redmine.find_user(test_email)
+        self.assertIsNotNone(user, f"Couldn't find user for {test_email}")
         self.assertEqual(test_email, user.mail)
         self.assertTrue(self.redmine.is_user_in_team(user.login, "users"))
         

--- a/test_netbot.py
+++ b/test_netbot.py
@@ -101,7 +101,11 @@ class TestNetbot(test_utils.BotTestCase):
         log.info(f"### ticket: {ticket}")
         #self.assertIn(body, ticket.journals[-1].notes) NOT until thread history is working
         
-        
+    async def test_on_application_command_error(self):
+        ctx = self.build_context()
+        error = discord.DiscordException("this is exception " + self.tag)
+        self.bot.on_application_command_error(ctx, error)
+        self.assertIn(self.tag, ctx.respond.call_args.args[0])
 
     
 

--- a/test_netbot.py
+++ b/test_netbot.py
@@ -89,8 +89,6 @@ class TestNetbot(test_utils.BotTestCase):
         await self.bot.synchronize_ticket(ticket, thread)
         
         # assert method send called on mock thread, with the correct values
-        log.info(f"### call args:{type(thread.send.call_args)} {thread.send.call_args}")
-        #'> **test-s7fkwk Testy** at *2024-01-18T00:19:32Z*\n> Body for test s7fkwk __main__.TestNetbot.test_synchronize_ticket\n\n')
         self.assertIn(self.tag, thread.send.call_args.args[0])
         self.assertIn(self.fullName, thread.send.call_args.args[0])
         self.assertIn(body, thread.send.call_args.args[0])
@@ -98,13 +96,14 @@ class TestNetbot(test_utils.BotTestCase):
         # get notes from redmine, assert tags in most recent
         check_ticket = self.redmine.get_ticket(ticket.id, include_journals=True) # get the notes
         self.assertIsNotNone(ticket)
-        log.info(f"### ticket: {ticket}")
+        #log.info(f"### ticket: {ticket}")
         #self.assertIn(body, ticket.journals[-1].notes) NOT until thread history is working
+        
         
     async def test_on_application_command_error(self):
         ctx = self.build_context()
         error = discord.DiscordException("this is exception " + self.tag)
-        self.bot.on_application_command_error(ctx, error)
+        await self.bot.on_application_command_error(ctx, error)
         self.assertIn(self.tag, ctx.respond.call_args.args[0])
 
     

--- a/test_netbot.py
+++ b/test_netbot.py
@@ -23,6 +23,7 @@ class TestNetbot(test_utils.BotTestCase):
         netbot.setup_logging() # for coverage?
         
         
+    @unittest.skip # On message is disabled
     async def test_new_message_synced_thread(self):
         test_ticket = 218
         note = f"This is a new note about ticket #{test_ticket} for test {self.tag}"
@@ -33,7 +34,7 @@ class TestNetbot(test_utils.BotTestCase):
         message = unittest.mock.AsyncMock(discord.Message)
         message.content = note
         message.channel = unittest.mock.AsyncMock(discord.Thread)
-        message.channel.name = f"Ticket #{test_ticket}: Search for subject match in email threading"
+        message.channel.name = f"Ticket #{test_ticket}"
         message.author = unittest.mock.AsyncMock(discord.Member)
         message.author.name = self.discord_user
         

--- a/test_netbot.py
+++ b/test_netbot.py
@@ -20,9 +20,28 @@ class TestNetbot(test_utils.BotTestCase):
         
     def setUp(self):
         super().setUp()
-        netbot.setup_logging() # for coverage?
+        netbot.setup_logging() 
+        self.bot = netbot.NetBot(self.redmine)
         
-        
+##- call setup_logging in a test, (just for cov)
+##- and each of on_ready
+##- comment out on_guild_join and on_thread_join (just info logs)
+##- comment out sync_new_message
+##- test-call sync with a *new* ticket, not existing
+#- add test messages to thread.history for syncronize_ticket <<< !!! FIXME
+#- add trivial test for on_application_command_error
+    
+    """
+    @unittest.skip # disabled, not needed
+    async def test_on_ready(self):
+        try:
+            await self.bot.on_ready()
+            # pass
+        except Exception as ex:
+            log.error(f"Exception: {ex}")
+            self.fail(f'Exception raised: {ex}')
+          
+            
     @unittest.skip # On message is disabled
     async def test_new_message_synced_thread(self):
         test_ticket = 218
@@ -44,6 +63,46 @@ class TestNetbot(test_utils.BotTestCase):
         ticket = self.redmine.get_ticket(218, include_journals=True) # get the notes
         self.assertIsNotNone(ticket)
         self.assertIn(note, ticket.journals[-1].notes)
+    """        
+
+    async def test_synchronize_ticket(self):
+        # create a new ticket, identified by the tag, with a note
+        subject = f"Testing {self.tag} {unittest.TestCase.id(self)}"
+        body = f"Body for test {self.tag} {unittest.TestCase.id(self)}"
+        ticket = self.redmine.create_ticket(self.user, subject, body)
+        self.redmine.append_message(ticket.id, self.user.login, body) # re-using tagged str
+        
+        # create mock message and thread
+        message = unittest.mock.AsyncMock(discord.Message)
+        message.content = f"This is a new note about ticket #{ticket.id} for test {self.tag}"
+        message.author = unittest.mock.AsyncMock(discord.Member)
+        message.author.name = self.discord_user
+        
+        thread = unittest.mock.AsyncMock(discord.Thread)
+        thread.name = f"Ticket #{ticket.id}"
+        # https://docs.python.org/3/library/unittest.mock-examples.html#mocking-asynchronous-iterators
+        ### FIXME
+        #thread.history = unittest.mock.AsyncMock(discord.iterators.HistoryIterator)
+        #thread.history.__aiter__.return_value = [message, message]
+        
+        # synchronize!
+        await self.bot.synchronize_ticket(ticket, thread)
+        
+        # assert method send called on mock thread, with the correct values
+        log.info(f"### call args:{type(thread.send.call_args)} {thread.send.call_args}")
+        #'> **test-s7fkwk Testy** at *2024-01-18T00:19:32Z*\n> Body for test s7fkwk __main__.TestNetbot.test_synchronize_ticket\n\n')
+        self.assertIn(self.tag, thread.send.call_args.args[0])
+        self.assertIn(self.fullName, thread.send.call_args.args[0])
+        self.assertIn(body, thread.send.call_args.args[0])
+        
+        # get notes from redmine, assert tags in most recent
+        check_ticket = self.redmine.get_ticket(ticket.id, include_journals=True) # get the notes
+        self.assertIsNotNone(ticket)
+        log.info(f"### ticket: {ticket}")
+        #self.assertIn(body, ticket.journals[-1].notes) NOT until thread history is working
+        
+        
+
     
 
 if __name__ == '__main__':

--- a/test_utils.py
+++ b/test_utils.py
@@ -34,8 +34,44 @@ def tagstr() -> str:
     """convert the current timestamp in seconds to a base36 str"""
     return dumps(int(time.time()))
 
+def create_test_user(redmine:Client, tag:str):
+    # create new test user name: test-12345@example.com, login test-12345        
+    first = "test-" + tag
+    last = "Testy"
+    #fullname = f"{first} {last}" ### <--
+    email = first + "@example.com"
+    
+    # create new redmine user, using redmine api
+    user = redmine.create_user(email, first, last)
+    
+    # create temp discord mapping with redmine api, assert 
+    discord_user = "discord-" + tag ### <--
+    redmine.create_discord_mapping(user.login, discord_user)
+    
+    # reindex users and lookup based on login
+    redmine.reindex_users()
+    return redmine.find_user(user.login)
+
 
 class BotTestCase(unittest.IsolatedAsyncioTestCase):
+    redmine = None
+    usertag = None
+    user = None
+    
+    @classmethod
+    def setUpClass(cls):
+        log.info("Setting up test fixtures")
+        cls.redmine = Client()
+        cls.usertag = tagstr()
+        cls.user = create_test_user(cls.redmine, cls.usertag)
+        log.info(f"Created test user: {cls.user}")
+
+
+    @classmethod
+    def tearDownClass(cls):
+        log.info(f"Tearing down test fixtures: {cls.user}")
+        cls.redmine.remove_user(cls.user.id)
+    
     
     def build_context(self) -> ApplicationContext:
         ctx = mock.AsyncMock(ApplicationContext)
@@ -46,33 +82,19 @@ class BotTestCase(unittest.IsolatedAsyncioTestCase):
     
     
     def setUp(self):
-        self.redmine = Client()
-        self.bot = NetBot(self.redmine)
+        # use the fixture-created client, bot, user
+        #self.redmine = REDMINE
+        #self.bot = NETBOT
         
-        # create a test user. this could be a fixture!
-        # create new test user name: test-12345@example.com, login test-12345
-        self.tag = tagstr()
-        first = "test-" + self.tag
-        last = "Testy"
-        self.fullName = f"{first} {last}"
-        email = first + "@example.com"
-        self.discord_user = "discord-" + self.tag 
-        # create new redmine user, using redmine api
-        self.user = self.redmine.create_user(email, first, last)
+        self.tag = self.__class__.usertag
+        #self.user = USER
+        self.assertIsNotNone(self.tag)
         self.assertIsNotNone(self.user)
-        self.assertEqual(email, self.user.login)
-        # create temp discord mapping with redmine api, assert 
-        self.redmine.create_discord_mapping(self.user.login, self.discord_user)
-        # reindex users and lookup based on login
-        self.redmine.reindex_users()
+        
+        self.fullName = self.user.firstname + " " +  self.user.lastname
+        self.discord_user = self.redmine.get_discord_id(self.user)
+
         self.assertIsNotNone(self.redmine.find_user(self.user.login))
         self.assertIsNotNone(self.redmine.find_user(self.discord_user))
-
-
-    def tearDown(self):
-        # delete user with redmine api, assert
-        self.redmine.remove_user(self.user.id)
-        self.redmine.reindex_users()
-        self.assertIsNone(self.redmine.find_user(self.user.login))
-        self.assertIsNone(self.redmine.find_user(self.discord_user))
-    
+        
+        log.debug(f"setUp user {self.user.login} {self.discord_user}")

--- a/test_utils.py
+++ b/test_utils.py
@@ -82,12 +82,7 @@ class BotTestCase(unittest.IsolatedAsyncioTestCase):
     
     
     def setUp(self):
-        # use the fixture-created client, bot, user
-        #self.redmine = REDMINE
-        #self.bot = NETBOT
-        
-        self.tag = self.__class__.usertag
-        #self.user = USER
+        self.tag = self.__class__.usertag # TODO just rename usertag to tag - represents the suite run
         self.assertIsNotNone(self.tag)
         self.assertIsNotNone(self.user)
         


### PR DESCRIPTION
Underlying issue: Trying to do too much by catching several async events to update redmine.

First, figured out the snowflake problem, which was literal zero was name a valid parameter for "all messages since the beginning". used "2 years ago" instead.

Once that was fixed, there was a lot of duplication due to async events copying messages over in the same second the periodic sync ran. removed all the event handling to use only the regular sync, which is configured to run every minute.

The one issue I ran into is setting up mocks for the AsyncIterator that discord.thread.history() uses, so I have not been able to mock test cases that simulate thread history in discord.