### PR TITLE
Ticket 480

### DIFF
--- a/cog_scn.py
+++ b/cog_scn.py
@@ -88,6 +88,8 @@ class SCNCog(commands.Cog):
                 # no user exists for that login
                 modal = NewUserModal(self.redmine, title="Create new user in Redmine")
                 await ctx.send_modal(modal)
+            # reindex users after changes
+            self.redmine.reindex_users()
 
 
     async def sync_thread(self, thread:discord.Thread):

--- a/netbot.py
+++ b/netbot.py
@@ -115,8 +115,9 @@ class NetBot(commands.Bot):
             formatted = f'"Discord":{message.jump_url}: {message.content}'
             self.redmine.append_message(ticket.id, user.login, formatted)
         else:
+            # no user mapping
             log.debug(f"SYNC unknown Discord user: {message.author.name}")
-            formatted = f'"Discord":{message.jump_url} {message.author.name}: {message.content}'
+            formatted = f'"Discord":{message.jump_url} user *{message.author.name}* said: {message.content}'
             # force user_login to None to use default user based on token (the admin)
             self.redmine.append_message(ticket.id, user_login=None, note=formatted)
 
@@ -210,7 +211,7 @@ def main():
 
 def setup_logging():
     """set up logging for netbot"""
-    logging.basicConfig(level=logging.INFO,
+    logging.basicConfig(level=logging.DEBUG,
                         format="{asctime} {levelname:<8s} {name:<16} {message}", style='{')
     logging.getLogger("discord.gateway").setLevel(logging.WARNING)
     logging.getLogger("discord.http").setLevel(logging.WARNING)

--- a/redmine.py
+++ b/redmine.py
@@ -502,6 +502,7 @@ class Client(): ## redmine.Client()
             ]
         }
         self.update_user(user, fields)
+        # TODO rebuild user index automatically?
 
 
     def join_team(self, username, teamname:str):


### PR DESCRIPTION
Pull request for ticket 480.
* Messages to a thread synced with redmine are marked with a note of the user's discord ID when that user does not have a mapping.
* A response is displayed to the Discord user, explaining how to map the Discord ID when that user does not have a mapping.
* If a redmine user does not exist, one will be created via a Discord popup modal dialog to collect first name, last name, and email.