### PR TITLE
ticket 614 - better UX in ticket thread creation

### DIFF
--- a/redmine.py
+++ b/redmine.py
@@ -181,41 +181,8 @@ class Client():
     # Starting to move fields out to their own methods, to eventually move to
     # their own Ticket class.
     def get_field(self, ticket, fieldname):
-        try:
-            match fieldname:
-                case "id":
-                    return f"{ticket.id}"
-                case "url":
-                    return f"{self.url}/issues/{ticket.id}"
-                case "link":
-                    return f"[{ticket.id}]({self.url}/issues/{ticket.id})"
-                case "priority":
-                    return ticket.priority.name
-                case "updated":
-                    return ticket.updated_on # string, or dt?
-                case "assigned":
-                    return ticket.assigned_to.name
-                case "status":
-                    return ticket.status.name
-                case "subject":
-                    return ticket.subject
-                case "title":
-                    return ticket.title
-                #case "age":
-                #    updated = dt.datetime.fromisoformat(ticket.updated_on) ### UTC
-                #    age = dt.datetime.now(dt.timezone.utc) - updated
-                #    return humanize.naturaldelta(age)
-                #case "sync":
-                #    try:
-                #        # Parse custom_field into datetime
-                #        # FIXME: this is fragile: relies on specific index of custom field, add custom field lookup by name
-                #        timestr = ticket.custom_fields[1].value
-                #        return dt.datetime.fromisoformat(timestr) ### UTC
-                #    except Exception as e:
-                #        log.debug(f"sync tag not set")
-                #        return None
-        except AttributeError:
-            return "" # or None?
+        return self.ticket_mgr.get_field(ticket, fieldname)
+
 
     def get_discord_id(self, user):
         if user:

--- a/test_cog_tickets.py
+++ b/test_cog_tickets.py
@@ -98,11 +98,8 @@ class TestTicketsCog(test_utils.BotTestCase):
 
     # create thread/sync
     async def test_thread_sync(self):
-
         # create a ticket and add a note
         note = f"This is a test note tagged with {self.tag}"
-        old_message = f"This is a sync message with {self.tag}"
-
         ticket = self.create_test_ticket()
         self.redmine.append_message(ticket.id, self.user.login, note)
 
@@ -110,31 +107,19 @@ class TestTicketsCog(test_utils.BotTestCase):
         ctx = self.build_context()
         ctx.channel = unittest.mock.AsyncMock(discord.TextChannel)
         ctx.channel.name = f"Test Channel {self.tag}"
-        #ctx.channel.id = self.tag
 
         thread = unittest.mock.AsyncMock(discord.Thread)
         thread.name = f"Ticket #{ticket.id}: {ticket.subject}"
 
-        member = unittest.mock.AsyncMock(discord.Member)
-        member.name=self.user.discord_id
-
-        message = unittest.mock.AsyncMock(discord.Message)
-        message.channel = ctx.channel
-        message.content = old_message
-        message.author = member
-        message.create_thread = unittest.mock.AsyncMock(return_value=thread)
+        ctx.channel.create_thread = unittest.mock.AsyncMock(return_value=thread)
 
         # TODO setup history with a message from the user - disabled while I work out the history mock.
         #thread.history = unittest.mock.AsyncMock(name="history")
         #thread.history.flatten = unittest.mock.AsyncMock(name="flatten", return_value=[message])
 
-        ctx.send = unittest.mock.AsyncMock(return_value=message)
-
         await self.cog.thread_ticket(ctx, ticket.id)
 
-        response = ctx.send.call_args.args[0]
-        thread_response = str(message.create_thread.call_args) # FIXME
-        self.assertIn(str(ticket.id), response)
+        thread_response = str(ctx.channel.create_thread.call_args) # FIXME
         self.assertIn(str(ticket.id), thread_response)
         self.assertIn(ticket.subject, thread_response)
 

--- a/tickets.py
+++ b/tickets.py
@@ -222,7 +222,7 @@ class Ticket():
 
         return notes
 
-    def get_field(self, fieldname):
+    def get_field(self, fieldname:str):
         val = getattr(self, fieldname)
         #log.debug(f">>> {fieldname} = {val}, type={type(val)}")
         return val
@@ -641,42 +641,19 @@ class TicketManager():
     # NOTE: This implies that ticket should be a full object with methods.
     # Starting to move fields out to their own methods, to eventually move to
     # their own Ticket class.
-    def get_field(self, ticket, fieldname):
+    def get_field(self, ticket:Ticket, fieldname:str) -> str:
         try:
             match fieldname:
-                case "id":
-                    return f"{ticket.id}"
                 case "url":
                     return f"{self.url}/issues/{ticket.id}"
                 case "link":
                     return f"[{ticket.id}]({self.url}/issues/{ticket.id})"
-                case "priority":
-                    return ticket.priority.name
                 case "updated":
-                    return ticket.updated_on # string, or dt?
-                case "assigned":
-                    return ticket.assigned_to.name
-                case "status":
-                    return ticket.status.name
-                case "subject":
-                    return ticket.subject
-                case "title":
-                    return ticket.title
-                #case "age":
-                #    updated = dt.datetime.fromisoformat(ticket.updated_on) ### UTC
-                #    age = dt.datetime.now(dt.timezone.utc) - updated
-                #    return humanize.naturaldelta(age)
-                #case "sync":
-                #    try:
-                #        # Parse custom_field into datetime
-                #        # FIXME: this is fragile: relies on specific index of custom field, add custom field lookup by name
-                #        timestr = ticket.custom_fields[1].value
-                #        return dt.datetime.fromisoformat(timestr) ### UTC
-                #    except Exception as e:
-                #        log.debug(f"sync tag not set")
-                #        return None
+                    return str(ticket.updated_on) # formatted string, or dt?
+                case _:
+                    return str(ticket.get_field(fieldname))
         except AttributeError:
-            return "" # or None?
+            return None
 
 
 def main():


### PR DESCRIPTION
Adding ticket description to new threads, and linking both ticket and thread in the Discord response. Updated test cases.

* Add ticket description to new ticket threads.
* Add a link to the redmine ticket in the thread-creation response.

Test cases pass and have been updated to reflect UX changes.
