### PR TITLE
Ticket 669 - Implement sync for Discord threads without tickets

### DIFF
--- a/cog_scn.py
+++ b/cog_scn.py
@@ -111,7 +111,14 @@ class SCNCog(commands.Cog):
                     message = Message(user.login, subject) # user.mail?
                     message.note = subject + "\n\nCreated by netbot by syncing Discord thread with same name."
                     ticket = self.redmine.ticket_mgr.create(user, message)
-                    # TODO set tracker
+                    # set tracker
+                    #tracker = self.bot.lookup_tracker(thread.parent.name)
+                    #if tracker:
+                    #    log.debug(f"found {thread.parent.name} => {tracker}")
+                    #    params = { "tracker_id": str(tracker.id) }
+                    #    self.redmine.ticket_mgr.update(ticket.id, params, user.login)
+                    #else:
+                    #    log.debug(f"not tracker for {thread.parent.name}")
                     # rename thread
                     await thread.edit(name=f"Ticket #{ticket.id}: {ticket.subject}")
                     # sync

--- a/cog_scn.py
+++ b/cog_scn.py
@@ -112,16 +112,22 @@ class SCNCog(commands.Cog):
                     message.note = subject + "\n\nCreated by netbot by syncing Discord thread with same name."
                     ticket = self.redmine.ticket_mgr.create(user, message)
                     # set tracker
-                    #tracker = self.bot.lookup_tracker(thread.parent.name)
-                    #if tracker:
-                    #    log.debug(f"found {thread.parent.name} => {tracker}")
-                    #    params = { "tracker_id": str(tracker.id) }
-                    #    self.redmine.ticket_mgr.update(ticket.id, params, user.login)
-                    #else:
-                    #    log.debug(f"not tracker for {thread.parent.name}")
+                    # TODO: search up all parents in hierarchy?
+                    tracker = self.bot.lookup_tracker(thread.parent.name)
+                    if tracker:
+                        log.debug(f"found {thread.parent.name} => {tracker}")
+                        params = {
+                            "tracker_id": str(tracker.id),
+                            "notes": f"Setting tracker based on channel name: {thread.parent.name}"
+                        }
+                        self.redmine.ticket_mgr.update(ticket.id, params, user.login)
+                    else:
+                        log.debug(f"not tracker for {thread.parent.name}")
+
                     # rename thread
                     await thread.edit(name=f"Ticket #{ticket.id}: {ticket.subject}")
-                    # sync
+
+                    # sync the thread
                     ticket = await self.bot.sync_thread(thread) # refesh the ticket
                     await ctx.respond(self.bot.formatter.format_ticket(ticket))
 

--- a/cog_scn.py
+++ b/cog_scn.py
@@ -116,7 +116,7 @@ class SCNCog(commands.Cog):
                     await thread.edit(name=f"Ticket #{ticket.id}: {ticket.subject}")
                     # sync
                     ticket = await self.bot.sync_thread(thread) # refesh the ticket
-                    await ctx.respond(f"Converted thread into ticket #{ticket.id}") # TODO add ticket link
+                    await ctx.respond(self.bot.formatter.format_ticket(ticket))
 
                 #OLD await ctx.respond(f"Cannot find ticket# in thread name: {ctx.channel.name}") # error
         else:

--- a/cog_tickets.py
+++ b/cog_tickets.py
@@ -7,7 +7,7 @@ import logging
 import discord
 
 from discord.commands import option
-from discord.ext import commands, tasks
+from discord.ext import commands
 
 from model import Message, Ticket
 from redmine import Client

--- a/cog_tickets.py
+++ b/cog_tickets.py
@@ -115,7 +115,8 @@ class TicketsCog(commands.Cog):
     async def create_thread(self, ticket:Ticket, ctx:discord.ApplicationContext):
         log.info(f"creating a new thread for ticket #{ticket.id} in channel: {ctx.channel}")
         thread_name = f"Ticket #{ticket.id}: {ticket.subject}"
-        thread = await ctx.channel.create_thread(name=thread_name)
+        # added public_thread type param
+        thread = await ctx.channel.create_thread(name=thread_name, type=discord.ChannelType.public_thread)
         # ticket-614: Creating new thread should post the ticket details to the new thread
         await thread.send(self.bot.formatter.format_ticket_details(ticket))
         return thread

--- a/formatting.py
+++ b/formatting.py
@@ -95,6 +95,14 @@ class DiscordFormatter():
         return f"> **{note.user}** *{age} ago*\n> {note.notes}"[:MAX_MESSAGE_LEN]
 
 
+    def format_ticket(self, ticket:Ticket) -> str:
+        link = self.format_link(ticket)
+        status = f"{EMOJI[ticket.status.name]} {ticket.status.name}"
+        priority = f"{EMOJI[ticket.priority.name]} {ticket.priority.name}"
+        assigned = ticket.assigned_to.name if ticket.assigned_to else ""
+        return " ".join([link, priority, status, ticket.tracker.name, assigned, ticket.subject])
+
+
     def format_ticket_details(self, ticket:Ticket) -> str:
         link = self.format_link(ticket)
         # link is mostly hidden, so we can't use the length to format.

--- a/netbot.py
+++ b/netbot.py
@@ -350,7 +350,7 @@ class NetBot(commands.Bot):
 
 
     def lookup_tracker(self, tracker:str) -> NamedId:
-        return self.trackers[tracker]
+        return self.trackers.get(tracker, None)
 
 
 def main():
@@ -371,7 +371,7 @@ def main():
 
 def setup_logging():
     """set up logging for netbot"""
-    logging.basicConfig(level=logging.DEBUG,
+    logging.basicConfig(level=logging.INFO,
                         format="{asctime} {levelname:<8s} {name:<16} {message}", style='{')
     logging.getLogger("discord.gateway").setLevel(logging.WARNING)
     logging.getLogger("discord.http").setLevel(logging.WARNING)

--- a/test_cog_scn.py
+++ b/test_cog_scn.py
@@ -189,7 +189,7 @@ class TestSCNCog(test_utils.BotTestCase):
 
         try:
             # synchronize thread
-            await self.cog.sync_thread(thread)
+            await self.bot.sync_thread(thread)
             self.fail("No exception when one was expected")
         except Exception as ex:
             self.assertIn(f"Ticket {ticket.id}", str(ex))

--- a/tickets.py
+++ b/tickets.py
@@ -9,7 +9,7 @@ import urllib.parse
 
 
 
-from model import SYNC_FIELD_NAME, TO_CC_FIELD_NAME, User, Message, NamedId, Team, Ticket, TicketNote, TicketsResult
+from model import TO_CC_FIELD_NAME, User, Message, NamedId, Team, Ticket, TicketNote, TicketsResult
 from session import RedmineSession, RedmineException
 import synctime
 
@@ -486,7 +486,7 @@ def main():
     #print(ticket_mgr.get(105, include_children=True).json_str())
     #print(json.dumps(ticket_mgr.load_custom_fields(), indent=4, default=vars))
 
-    #print(ticket_mgr.due())
+    print(ticket_mgr.due())
 
 # for testing the redmine
 if __name__ == '__main__':

--- a/tickets.py
+++ b/tickets.py
@@ -54,7 +54,7 @@ class TicketManager():
         if response:
             trackers = {}
             for item in response['trackers']:
-                print(f"##### {item}")
+                #print(f"##### {item}")
                 trackers[item['name']] = NamedId(id=item['id'], name=item['name'])
             return trackers
         else:

--- a/tickets.py
+++ b/tickets.py
@@ -48,6 +48,19 @@ class TicketManager():
             log.warning("No custom fields to load")
 
 
+    def load_trackers(self) -> dict[str,NamedId]:
+        # call redmine to get the ticket trackers
+        response = self.session.get("/trackers.json")
+        if response:
+            trackers = {}
+            for item in response['trackers']:
+                print(f"##### {item}")
+                trackers[item['name']] = NamedId(id=item['id'], name=item['name'])
+            return trackers
+        else:
+            log.warning("No custom fields to load")
+
+
     def get_field_id(self, name:str) -> int | None:
         if name in self.custom_fields:
             return self.custom_fields[name].id


### PR DESCRIPTION
Implements changes related to creating redmine ticket from Discord.

The command, '/scn sync', when executed within an existing Discord thread, creates a new ticket from the existing thread, such that:
* The new ticket has the subject taken from the existing thread title
* The new ticket will have a description the matches the title, with a description of how it was created
* The ticket's creator is the redmine user associated with the Discord account
* The new ticket tracker will be based on the parent channel of the thread
* Each message in the thread will be copied as a note to the new ticket, with the discord user translated to redmine user

Further, new tickets created with '/new' will automatically create threads.
