### PR TITLE
Ticket 787 - Clean up UX for Discord bot ticket commands

### DIFF
--- a/cog_scn.py
+++ b/cog_scn.py
@@ -8,7 +8,7 @@ from discord.commands import SlashCommandGroup
 from discord.ext import commands
 
 from model import Message
-from redmine import Client
+from redmine import Client, BLOCKED_TEAM_NAME
 
 
 log = logging.getLogger(__name__)
@@ -188,13 +188,20 @@ class SCNCog(commands.Cog):
                 await ctx.respond(f"Unknown team name: {teamname}") # error
         else:
             # all teams
-            teams = self.redmine.get_teams()
+            teams = self.redmine.user_mgr.cache.get_teams()
             buff = ""
-            for teamname in teams:
-                team = self.redmine.get_team(teamname)
-                #await self.print_team(ctx, team)
+            for team in teams:
                 buff += self.format_team(team)
             await ctx.respond(buff[:2000]) # truncate!
+
+
+    @scn.command(description="list blocked email")
+    async def blocked(self, ctx:discord.ApplicationContext):
+        team = self.redmine.get_team(BLOCKED_TEAM_NAME)
+        if team:
+            await ctx.respond(self.format_team(team))
+        else:
+            await ctx.respond(f"Expected team {BLOCKED_TEAM_NAME} not configured") # error
 
 
     # ticket 484 - http://10.10.0.218/issues/484

--- a/docs/netbot-usage.md
+++ b/docs/netbot-usage.md
@@ -105,31 +105,92 @@ Should be the same as `/scn teams blocked`.
 
 ## Ticket Commands
 
-The `/ticket` command is used to information about tickets in Redmine
+The `/ticket` slash command is used to information about tickets in Redmine. A number of commands are provided:
+* query
+* details
+* new
+* thread
+* assign
+* unassign
+* progress
+* resolve
 
-### /ticket query me
-- The the list of tickets for *me* (you, the reader) to work on
+### `/ticket query me` - Query my tickets
 
-### /ticket query [term]
-- *term* can be a user, a team or any term that will be used for a full text search for tickets (open and closed) that match the *term*.
+The the list of tickets for *me* (you, the reader) to work on.
 
-### /ticket details [ticket-id]
-- Show ticket *ticket-id* with full details.
+```
+/ticket query me
+```
 
-### /ticket new [title]
-- Create a new ticket, with the associated title. This will also create a new Discord thread for the ticket. If the command is issued in an existing thread, that thread is used and synched with redmine.
+### `/ticket query [term]` - Query tickets about *term*
 
-### /ticket thread [ticket-id]
-- Create a new discord thread from an existing ticket *ticket-id*, using the ticket title as the thread title. The thread is created in the channel it is invoked in, and all notes from the existing ticket are copied into the thread.
+*term* can be a user, a team or any term that will be used for a full text search for tickets (open and closed) that match the *term*.
 
-### /ticket assign [ticket-id]
-- Assign ticket *ticket-id* to yourself (the invoking user)
+```
+/ticket query test
+```
+will return any tickets that reference the term "test".
 
-### /ticket unassign [ticket-id]
-- Mark ticket *ticket-id* new and unassigned.
+### `/ticket details [ticket-id]` - Show details about a specific ticket
 
-### /ticket progress [ticket-id]
--  Mark ticket *ticket-id* to in-progress and assign it to yourself.
+Show ticket *ticket-id* with full details.
 
-### /ticket resolve [ticket-id]
-- Mark ticket *ticket-id* resolved.
+```
+/ticket details 787
+```
+will display all the ticket information for ticket ID 787
+
+### `/ticket new [title]` - Create a new ticket
+
+Create a new ticket, with the associated title. This will also create a new Discord thread for the ticket. If the command is issued in an existing thread, that thread is used and synched with redmine.
+
+```
+/ticket new Upgrade the server to the v1.62 LTS
+```
+Will create a new ticket with the title "Upgrade the server to the v1.62 LTS", and a thread for the new ticket in Discord.
+
+### `/ticket thread [ticket-id]` - Create a Discord thread for a ticket
+
+Create a new discord thread from an existing ticket *ticket-id*, using the ticket title as the thread title. The thread is created in the channel it is invoked in, and all notes from the existing ticket are copied into the thread.
+
+```
+/ticket thread 787
+```
+will create a new thread for ticket 787 in the current Discord channel.
+
+### `/ticket assign [ticket-id]` - Assign a ticket
+
+Assign ticket *ticket-id* to yourself (the invoking user).
+
+```
+/ticket assign 787
+```
+will assign ticket 787 to you.
+
+### `/ticket unassign [ticket-id]` - Unassign a ticket
+
+Mark ticket *ticket-id* new and unassigned, so it can be assigned for someone else to work on.
+
+```
+/ticket unassign 787
+```
+will unassign (you) from ticker 787 and set it's status to "new" and it's owner to "intake".
+
+### `/ticket progress [ticket-id]` - Set a ticket to in-progress
+
+Mark ticket *ticket-id* to in-progress and assign it to yourself.
+
+```
+/ticket progress 787
+```
+will set the status of ticket 787 to in-progress and assign it to you.
+
+### `/ticket resolve [ticket-id]` - Resolve a ticket
+
+Mark ticket *ticket-id* resolved.
+
+```
+/ticket thread 787
+```
+will mark ticket 787 resolved. Well done!

--- a/docs/netbot-usage.md
+++ b/docs/netbot-usage.md
@@ -102,42 +102,34 @@ List the blocked users.
 
 Should be the same as `/scn teams blocked`.
 
+
 ## Ticket Commands
 
-The `/tickets` command is used to information about tickets in Redmine
+The `/ticket` command is used to information about tickets in Redmine
 
-### /tickets
-- My tickets
+### /ticket query me
+- The the list of tickets for *me* (you, the reader) to work on
 
-### /tickets team
-- Tickets assigned to team [team]
+### /ticket query [term]
+- *term* can be a user, a team or any term that will be used for a full text search for tickets (open and closed) that match the *term*.
 
-### /tickets user
-- Tickets assigned to a specific [user]
+### /ticket details [ticket-id]
+- Show ticket *ticket-id* with full details.
 
-### /tickets query-term
-- Full text search for all tickets (open and closed) that match the query-term
+### /ticket new [title]
+- Create a new ticket, with the associated title. This will also create a new Discord thread for the ticket. If the command is issued in an existing thread, that thread is used and synched with redmine.
 
-### /ticket 42
-- Show ticket info for ticket 42
+### /ticket thread [ticket-id]
+- Create a new discord thread from an existing ticket *ticket-id*, using the ticket title as the thread title. The thread is created in the channel it is invoked in, and all notes from the existing ticket are copied into the thread.
 
-### /ticket 42 details
-- Show ticket 42 with all notes (in a decent format)
+### /ticket assign [ticket-id]
+- Assign ticket *ticket-id* to yourself (the invoking user)
 
-### /ticket 42 assign
-- Assign ticket 42 to yourself (the invoking user)
-- `/ticket 42 assign @bob` would assign ticket 42 to Bob.
+### /ticket unassign [ticket-id]
+- Mark ticket *ticket-id* new and unassigned.
 
-### /ticket 42 unassign
-- Mark ticket 42 new and unassigned.
+### /ticket progress [ticket-id]
+-  Mark ticket *ticket-id* to in-progress and assign it to yourself.
 
-### /ticket 42 progress
--  Set ticket 42 it to in-progress.
-
-### /ticket 42 resolve
-- Mark the ticket resolved.
-
-### /new Title of a new ticket to be created
-- Create a new ticket with the supplied title.
-- FUTURE: Will popup a modal dialog to collect ...
-- OR just supply params with default values for tracker, etc.
+### /ticket resolve [ticket-id]
+- Mark ticket *ticket-id* resolved.

--- a/model.py
+++ b/model.py
@@ -372,8 +372,6 @@ class Ticket():
         # Parse custom_field into datetime
         # lookup field by name
         token = self.get_custom_field(SYNC_FIELD_NAME)
-        #log.info(f"### found '{token}' for #{self.id}:{SYNC_FIELD_NAME}")
-        #log.info(f"### custom field: {self.custom_fields}")
         if token:
             record = synctime.SyncRecord.from_token(self.id, token)
             log.debug(f"created sync_rec from token: {record}")

--- a/netbot.py
+++ b/netbot.py
@@ -372,7 +372,7 @@ def main():
 
 def setup_logging():
     """set up logging for netbot"""
-    logging.basicConfig(level=logging.INFO,
+    logging.basicConfig(level=logging.DEBUG,
                         format="{asctime} {levelname:<8s} {name:<16} {message}", style='{')
     logging.getLogger("discord.gateway").setLevel(logging.WARNING)
     logging.getLogger("discord.http").setLevel(logging.WARNING)

--- a/redmine.py
+++ b/redmine.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 
 import synctime
 from session import RedmineSession
-from model import Message, Ticket, User
+from model import Message, Ticket, User, Team
 from users import UserManager
 from tickets import TicketManager, SCN_PROJECT_ID
 
@@ -170,8 +170,9 @@ class Client():
     def resolve_ticket(self, ticket_id, user_id=None):
         return self.ticket_mgr.resolve_ticket(ticket_id, user_id)
 
-    def get_team(self, teamname:str):
-        return self.user_mgr.get_team_by_name(teamname) # FIXME consistent naming
+    def get_team(self, teamname:str) -> Team:
+        #return self.user_mgr.get_team_by_name(teamname) # FIXME consistent naming
+        return self.user_mgr.cache.get_team_by_name(teamname)
 
     def update_sync_record(self, record:synctime.SyncRecord):
         log.debug(f"Updating sync record in redmine: {record}")

--- a/test_cog_tickets.py
+++ b/test_cog_tickets.py
@@ -55,21 +55,21 @@ class TestTicketsCog(test_utils.BotTestCase):
 
         # get the ticket using id
         ctx = self.build_context()
-        await self.cog.tickets(ctx, ticket_id)
+        await self.cog.query(ctx, ticket_id)
         response_str = ctx.respond.call_args.args[0]
         self.assertIn(ticket_id, response_str)
         self.assertIn(url, response_str)
 
         # get the ticket using tag
         ctx = self.build_context()
-        await self.cog.tickets(ctx, self.tag)
+        await self.cog.query(ctx, self.tag)
         response_str = ctx.respond.call_args.args[0]
         self.assertIn(ticket_id, response_str)
         self.assertIn(url, response_str)
 
         # assign the ticket
         ctx = self.build_context()
-        await self.cog.ticket(ctx, ticket_id, "assign")
+        await self.cog.assign(ctx, ticket_id)
         response_str = ctx.respond.call_args.args[0]
         self.assertIn(ticket_id, response_str)
         self.assertIn(url, response_str)
@@ -77,7 +77,7 @@ class TestTicketsCog(test_utils.BotTestCase):
 
         # "progress" the ticket, setting it in-progress and assigning it to "me"
         ctx = self.build_context()
-        await self.cog.ticket(ctx, ticket_id, "progress")
+        await self.cog.progress(ctx, ticket_id)
         response_str = ctx.respond.call_args.args[0]
         self.assertIn(ticket_id, response_str)
         self.assertIn(url, response_str)
@@ -85,7 +85,7 @@ class TestTicketsCog(test_utils.BotTestCase):
 
         # resolve the ticket
         ctx = self.build_context()
-        await self.cog.ticket(ctx, ticket_id, "resolve")
+        await self.cog.resolve(ctx, ticket_id)
         response_str = ctx.respond.call_args.args[0]
         self.assertIn(ticket_id, response_str)
         self.assertIn(url, response_str)
@@ -117,7 +117,7 @@ class TestTicketsCog(test_utils.BotTestCase):
         #thread.history = unittest.mock.AsyncMock(name="history")
         #thread.history.flatten = unittest.mock.AsyncMock(name="flatten", return_value=[message])
 
-        await self.cog.thread_ticket(ctx, ticket.id)
+        await self.cog.thread(ctx, ticket.id)
 
         thread_response = str(ctx.channel.create_thread.call_args) # FIXME
         self.assertIn(str(ticket.id), thread_response)

--- a/test_imap.py
+++ b/test_imap.py
@@ -141,8 +141,8 @@ class TestMessages(test_utils.RedmineTestCase):
 
         # search for the ticket
         tickets = self.redmine.match_subject(subject)
-        for check in tickets:
-            log.debug(f"### tickets: {check.subject}")
+        #for check in tickets:
+        #    log.debug(f"### tickets: {check.subject}")
         self.assertIsNotNone(tickets)
         self.assertEqual(1, len(tickets))
         self.assertEqual(ticket.id, tickets[0].id)

--- a/test_tickets.py
+++ b/test_tickets.py
@@ -48,7 +48,6 @@ class TestTicketManager(test_utils.MockRedmineTestCase):
         self.tickets_mgr.create(self.user, msg, test_proj_id)
 
         resp_ticket = json.loads(mock_post.call_args[0][1])["issue"]
-        #print("###", type(resp_ticket), resp_ticket)
 
         mock_post.assert_called_once()
         self.assertEqual(test_proj_id, resp_ticket['project_id'])

--- a/tickets.py
+++ b/tickets.py
@@ -55,7 +55,6 @@ class TicketManager():
         if response:
             trackers = {}
             for item in response['trackers']:
-                #print(f"##### {item}")
                 trackers[item['name']] = NamedId(id=item['id'], name=item['name'])
             return trackers
         else:

--- a/users.py
+++ b/users.py
@@ -292,7 +292,7 @@ class UserManager():
 
             return teams
         else:
-            log.warning("No users from get_all_users")
+            log.warning("No teams from get_all_teams")
             return []
 
 
@@ -331,6 +331,7 @@ class UserManager():
     def get_team_by_name(self, name:str) -> Team:
         # need to get all team, which builds a dicts of names
         teams = self.get_all_teams(include_users=False)
+        log.debug(f"teams: {teams}")
         if name in teams:
             return self.get_team(teams[name].id)
 


### PR DESCRIPTION
Refactored the Discord commends to be a lot more consistent:

- /ticket new
- /ticket query
- /ticket thread
- /ticket assign
- /ticket unassign
- /ticket progress
- /ticket resolve

See docs/netbot-usage.md for details.
