### PR TITLE
Ticket 797 -  Fix locking problem when handling exception during ticket sync

### DIFF
--- a/docs/netbot-usage.md
+++ b/docs/netbot-usage.md
@@ -153,11 +153,21 @@ Will create a new ticket with the title "Upgrade the server to the v1.62 LTS", a
 ### `/ticket thread [ticket-id]` - Create a Discord thread for a ticket
 
 Create a new discord thread from an existing ticket *ticket-id*, using the ticket title as the thread title. The thread is created in the channel it is invoked in, and all notes from the existing ticket are copied into the thread.
-
 ```
 /ticket thread 787
 ```
 will create a new thread for ticket 787 in the current Discord channel.
+
+If a Discord thread has already been created for that ticket, a note with a link to that thread will be displayed.
+
+If an existing *ticket thread* has been deleted, it can be recreated in any channel with the same command.
+
+To move a *ticket thread* to a new channel:
+1. Delete the existing *ticket thread* using the Discord UI. NOTE: The relevant comments are already synced to Redmine.
+2. Create the *ticket thread* in the new channel with (you guessed it): `/thread ticket [id]`
+
+`/ticket thread` is designed to be forgiving: If no *ticket thread* exists or syncdata is old, incomplete or invalid, a new valid *ticket thread* will be created and synchroized. Otherwise, an existing *ticket thread* is associated with that ticket ID and a link to it will be displayed.
+
 
 ### `/ticket assign [ticket-id]` - Assign a ticket
 

--- a/test_synctime.py
+++ b/test_synctime.py
@@ -24,7 +24,7 @@ class TestTime(test_utils.RedmineTestCase):
         ticket = self.create_test_ticket()
 
         test_channel = 4321
-        sync_rec = ticket.get_sync_record(expected_channel=test_channel)
+        sync_rec = ticket.validate_sync_record(expected_channel=test_channel)
         self.assertIsNotNone(sync_rec)
         self.assertEqual(sync_rec.ticket_id, ticket.id)
         self.assertEqual(sync_rec.channel_id, test_channel)
@@ -35,7 +35,7 @@ class TestTime(test_utils.RedmineTestCase):
 
         # refetch ticket
         ticket2 = self.redmine.get_ticket(ticket.id)
-        sync_rec2 = ticket2.get_sync_record(expected_channel=1111) # NOT the test_channel
+        sync_rec2 = ticket2.validate_sync_record(expected_channel=1111) # NOT the test_channel
         log.info(f"ticket2 updated={ticket2.updated_on}, {synctime.age_str(ticket2.updated_on)} ago, channel: {sync_rec.channel_id}")
 
         self.assertIsNone(sync_rec2)

--- a/tickets.py
+++ b/tickets.py
@@ -9,7 +9,7 @@ import urllib.parse
 
 
 
-from model import TO_CC_FIELD_NAME, User, Message, NamedId, Team, Ticket, TicketNote, TicketsResult
+from model import TO_CC_FIELD_NAME, User, Message, NamedId, Team, Ticket, TicketNote, TicketsResult, SYNC_FIELD_NAME
 from session import RedmineSession, RedmineException
 import synctime
 
@@ -468,10 +468,25 @@ class TicketManager():
         log.debug(f"Updating sync record in redmine: {record}")
         fields = {
             "custom_fields": [
-                { "id": 4, "value": record.token_str() } # cf_4, custom field syncdata, #TODO search for it
+                { "id": 4, "value": record.token_str() } # cf_4, custom field syncdata, #TODO see below
             ]
         }
         self.update(record.ticket_id, fields)
+
+
+    def remove_sync_record(self, record:synctime.SyncRecord):
+        field = self.custom_fields[SYNC_FIELD_NAME]
+        if field:
+            log.debug(f"Removing sync record in redmine: {record}")
+            fields = {
+                "custom_fields": [
+                    { "id": field.id, "value": "" }
+                ]
+            }
+            self.update(record.ticket_id, fields)
+            log.debug(f"Removed {SYNC_FIELD_NAME} from ticket {record.ticket_id}")
+        else:
+            log.error(f"Missing expected custom field: {SYNC_FIELD_NAME}")
 
 
     def get_updated_field(self, ticket) -> dt.datetime:


### PR DESCRIPTION
The fix for the lock with fairly simple, wrapping an in try/finally to release the lock. (It's using a double-loc idiom, and I couldn't figure out the "python" way to phrase it.)

The challenge was deconstructing the logic in `get_sync_record()`, which I refactored into `get_` and `validate_sync_record`, allowing a cleaner solution to conflict/error detection and resolution.

(WTF was I thinking in the original get_sync_record?)

It works under test and deployed to my integration test bed. The new links to existing threads is handy.