### PR TITLE
Ticket 1206 - Hide rejected/blocked/closed tickets in query command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ cython_debug/
 #.idea/
 .DS_Store
 pyrightconfig.json
+.vscode/

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -1,7 +1,15 @@
 ## Development Log
 
+### 2024-09-05
+*Haven't updated in a year. Sorry.*
+*I've got the notes, I just haven't put them here. I can if they are needed.*
+
+Using this as a change log (apart from git log).
+
+Fixed #[1206](http://172.16.20.20/issues/1206): Only open tickets are displayed in search results.
+
 ### 2023-08-29
-After the ticket workflow discussions, I've been thinking about how to better integrate the "issue source of truth" (was osticket, becomming redmine) with the tools that *humans* use for discussion and issue resolution (Discord). Esther suggested an integration that tracked ticket discussion in specific threads, which was similar to slack-thread-per-issue in a few startups. 
+After the ticket workflow discussions, I've been thinking about how to better integrate the "issue source of truth" (was osticket, becomming redmine) with the tools that *humans* use for discussion and issue resolution (Discord). Esther suggested an integration that tracked ticket discussion in specific threads, which was similar to slack-thread-per-issue in a few startups.
 
 The state of this thread tracking can be managed in redmine, using a custom boolean field attached to the issue. When this flag is enabled (for an open ticket), an external cron script can sync comments on a Discord thread with comments on the redmine ticket.
 
@@ -79,11 +87,11 @@ Basic idea -> command -> autocomplete-options -> command+params -> url/request -
   * options + autocomplete (interface with file-based impl is superclass?)
 	* url (with {} substitution tags)
 	* filter, perhaps several or iterating-filters, as per (details vs summary)
-	
+
 
 - commands:
   - my tickets:
-		- url: 
+		- url:
 		- filter:
 	- my [user,identity]:
 		- url:
@@ -172,7 +180,7 @@ pip install python-dotenv
 pip freeze > requirements.txt
 ```
 
-Example bot working. 
+Example bot working.
 
 #### netbox
 Moving on to netbox integration.

--- a/tickets.py
+++ b/tickets.py
@@ -405,10 +405,10 @@ class TicketManager():
 
 
     def search(self, term) -> list[Ticket]:
-        """search all text of all tickets (not just open) for the supplied terms"""
+        """search all text of open tickets for the supplied terms"""
         # todo url-encode term?
-        # note: sort doesn't seem to be working for search
-        query = f"/search.json?q={term}&issues=1&limit=100&sort={DEFAULT_SORT}"
+        # note: open_issues=1 is open issues only
+        query = f"/search.json?q={term}&issues=1&open_issues=1&limit=100"
 
         response = self.session.get(query)
         if not response:


### PR DESCRIPTION
Using a filter, `open_issues=1`, to limit API search results to open tickets.