### PR TITLE
Ticket-1207: Adding admin override for for `assign`, `progress` and `collaborate`

### DIFF
--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -1,5 +1,9 @@
 ## Development Log
 
+### 2024-09-24
+
+Starting work on ticket 1207, to add admin overrides for all actions that default to self.
+
 ### 2024-09-05
 *Haven't updated in a year. Sorry.*
 *I've got the notes, I just haven't put them here. I can if they are needed.*

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -4,6 +4,22 @@
 
 Starting work on ticket 1207, to add admin overrides for all actions that default to self.
 
+Added admin-specific params to allow member assignement for:
+* collaborate
+* progress
+* assign
+
+Adding ticket ID autofill if in ticket thread:
+* collaborate
+* progress
+* assign
+* unassign
+* resolve
+* tracker
+* priority
+* subject
+
+
 ### 2024-09-05
 *Haven't updated in a year. Sorry.*
 *I've got the notes, I just haven't put them here. I can if they are needed.*

--- a/netbot/cog_scn.py
+++ b/netbot/cog_scn.py
@@ -327,7 +327,7 @@ class SCNCog(commands.Cog):
             # add the user to the blocked list
             self.redmine.user_mgr.block(user)
             # search and reject all tickets from that user
-            for ticket in self.redmine.get_tickets_by(user):
+            for ticket in self.redmine.ticket_mgr.get_by(user):
                 self.redmine.reject_ticket(ticket.id)
             await ctx.respond(f"Blocked user: {user.login} and rejected all created tickets")
         else:

--- a/netbot/cog_scn.py
+++ b/netbot/cog_scn.py
@@ -4,12 +4,14 @@ import logging
 
 import discord
 
-from discord.commands import SlashCommandGroup
+from discord.commands import option, SlashCommandGroup
 from discord.ext import commands
+from discord.utils import basic_autocomplete
 
 from redmine.model import Message, User
 from redmine.redmine import Client, BLOCKED_TEAM_NAME
 
+from netbot.netbot import default_ticket
 
 log = logging.getLogger(__name__)
 
@@ -164,7 +166,10 @@ class SCNCog(commands.Cog):
         return False
 
 
-    @scn.command()
+    # FIXME rename to "register"?
+    @scn.command(description="Add a Discord user to redmine")
+    @option("ticket_id", description="ticket ID", autocomplete=basic_autocomplete(default_ticket))
+    @option("member", description="Discord member collaborating with ticket", optional=True)
     async def add(self, ctx:discord.ApplicationContext, redmine_login:str, member:discord.Member=None):
         """add a Discord user to the Redmine ticketing integration"""
         discord_name = ctx.user.name # by default, assume current user

--- a/netbot/cog_tickets.py
+++ b/netbot/cog_tickets.py
@@ -14,7 +14,7 @@ from discord.ui.item import Item, V
 from discord.utils import basic_autocomplete
 from redmine.model import Message, Ticket
 from redmine.redmine import Client
-from netbot.netbot import NetBot, TEAM_MAPPING, CHANNEL_MAPPING
+from netbot.netbot import NetBot, TEAM_MAPPING, CHANNEL_MAPPING, default_ticket
 
 
 log = logging.getLogger(__name__)
@@ -197,16 +197,6 @@ class EditSubjectAndDescModal(discord.ui.Modal):
         await interaction.response.send_message(f"EditView.callback() {interaction.data}")
 
 
-# WHERE SHOULD THIS GO?
-# returns ticket id or none
-def default_ticket(ctx: discord.AutocompleteContext) -> list[int]:
-    # examine the thread
-    ticket_id = ctx.bot.parse_thread_title(ctx.interaction.channel.name)
-    if ticket_id:
-        return [ticket_id]
-    else:
-        return []
-
 # distinct from above. takes app-context
 def default_term(ctx: discord.ApplicationContext) -> str:
     # examine the thread
@@ -321,7 +311,7 @@ class TicketsCog(commands.Cog):
 
     @ticket.command(description="Collaborate on a ticket")
     @option("ticket_id", description="ticket ID", autocomplete=basic_autocomplete(default_ticket))
-    @option("member", description="Discord member to collaborate", optional=True)
+    @option("member", description="Discord member collaborating with ticket", optional=True)
     async def collaborate(self, ctx: discord.ApplicationContext, ticket_id:int, member:discord.Member=None):
         """Add yourself as a collaborator on a ticket"""
         # lookup the user
@@ -384,6 +374,7 @@ class TicketsCog(commands.Cog):
 
     @ticket.command(description="Mark a ticket in-progress")
     @option("ticket_id", description="ticket ID", autocomplete=basic_autocomplete(default_ticket))
+    @option("member", description="Discord member taking ownership", optional=True)
     async def progress(self, ctx: discord.ApplicationContext, ticket_id:int, member:discord.Member=None):
         """Update status on a ticket, using: progress"""
         # lookup the user
@@ -410,6 +401,7 @@ class TicketsCog(commands.Cog):
 
     @ticket.command(description="Assign a ticket")
     @option("ticket_id", description="ticket ID", autocomplete=basic_autocomplete(default_ticket))
+    @option("member", description="Discord member taking ownership", optional=True)
     async def assign(self, ctx: discord.ApplicationContext, ticket_id:int, member:discord.Member=None):
         # lookup the user
         user_name = ctx.user.name

--- a/netbot/cog_tickets.py
+++ b/netbot/cog_tickets.py
@@ -237,7 +237,7 @@ class TicketsCog(commands.Cog):
         # special cases: ticket num and team name
         try:
             int_id = int(term)
-            ticket = self.redmine.get_ticket(int_id, include="children") # get the children
+            ticket = self.redmine.ticket_mgr.get(int_id, include="children") # get the children
             if ticket:
                 log.debug(f"QQQ<: {ticket}")
                 return [ticket]
@@ -312,33 +312,39 @@ class TicketsCog(commands.Cog):
     async def details(self, ctx: discord.ApplicationContext, ticket_id:int):
         """Update status on a ticket, using: unassign, resolve, progress"""
         #log.debug(f"found user mapping for {ctx.user.name}: {user}")
-        ticket = self.redmine.get_ticket(ticket_id, include="children")
+        ticket = self.redmine.ticket_mgr.get(ticket_id, include="children")
         if ticket:
             await self.bot.formatter.print_ticket(ticket, ctx)
         else:
             await ctx.respond(f"Ticket {ticket_id} not found.") # print error
 
 
-
     @ticket.command(description="Collaborate on a ticket")
-    @option("ticket_id", description="ticket ID")
-    async def collaborate(self, ctx: discord.ApplicationContext, ticket_id:int):
+    @option("ticket_id", description="ticket ID", autocomplete=basic_autocomplete(default_ticket))
+    @option("member", description="Discord member to collaborate", optional=True)
+    async def collaborate(self, ctx: discord.ApplicationContext, ticket_id:int, member:discord.Member=None):
         """Add yourself as a collaborator on a ticket"""
         # lookup the user
-        user = self.redmine.user_mgr.find(ctx.user.name)
+        user_name = ctx.user.name
+        if member:
+            if self.bot.is_admin(ctx.user):
+                log.info(f"ADMIN: {ctx.user.name} invoked collaborate on behalf of {member.name}")
+                user_name = member.name
+        user = self.redmine.user_mgr.find(user_name)
         if not user:
             await ctx.respond(f"User {ctx.user.name} not mapped to redmine. Use `/scn add [redmine-user]` to create the mapping.")
             return
-        ticket = self.redmine.get_ticket(ticket_id)
+
+        ticket = self.redmine.ticket_mgr.get(ticket_id)
         if ticket:
-            self.redmine.ticket_mgr.collaborate(ticket_id, user)
-            await self.bot.formatter.print_ticket(self.redmine.get_ticket(ticket_id), ctx)
+            self.redmine.ticket_mgr.collaborate(ticket.id, user)
+            await self.bot.formatter.print_ticket(self.redmine.ticket_mgr.get(ticket.id), ctx)
         else:
             await ctx.respond(f"Ticket {ticket_id} not found.") # print error
 
 
     @ticket.command(description="Unassign a ticket")
-    @option("ticket_id", description="ticket ID")
+    @option("ticket_id", description="ticket ID", autocomplete=basic_autocomplete(default_ticket))
     async def unassign(self, ctx: discord.ApplicationContext, ticket_id:int):
         """Update status on a ticket, using: unassign, resolve, progress"""
         # lookup the user
@@ -346,16 +352,17 @@ class TicketsCog(commands.Cog):
         if not user:
             await ctx.respond(f"User {ctx.user.name} not mapped to redmine. Use `/scn add` to create the mapping.") # error
             return
-        ticket = self.redmine.get_ticket(ticket_id)
+
+        ticket = self.redmine.ticket_mgr.get(ticket_id)
         if ticket:
-            self.redmine.unassign_ticket(ticket_id, user.login)
-            await self.bot.formatter.print_ticket(self.redmine.get_ticket(ticket_id), ctx)
+            self.redmine.ticket_mgr.unassign(ticket.id, user.login)
+            await self.bot.formatter.print_ticket(self.redmine.ticket_mgr.get(ticket.id), ctx)
         else:
             await ctx.respond(f"Ticket {ticket_id} not found.") # print error
 
 
     @ticket.command(description="Resolve a ticket")
-    @option("ticket_id", description="ticket ID")
+    @option("ticket_id", description="ticket ID", autocomplete=basic_autocomplete(default_ticket))
     async def resolve(self, ctx: discord.ApplicationContext, ticket_id:int):
         """Update status on a ticket, using: unassign, resolve, progress"""
         # lookup the user
@@ -363,9 +370,10 @@ class TicketsCog(commands.Cog):
         if not user:
             await ctx.respond(f"User {ctx.user.name} not mapped to redmine. Use `/scn add` to create the mapping.") # error
             return
-        ticket = self.redmine.get_ticket(ticket_id)
+
+        ticket = self.redmine.ticket_mgr.get(ticket_id)
         if ticket:
-            updated = self.redmine.resolve_ticket(ticket_id, user.login)
+            updated = self.redmine.ticket_mgr.resolve(ticket_id, user.login)
             ticket_link = self.bot.formatter.format_link(ticket)
             await ctx.respond(
                 f"Updated {ticket_link}, status: {ticket.status} -> {updated.status}",
@@ -375,16 +383,21 @@ class TicketsCog(commands.Cog):
 
 
     @ticket.command(description="Mark a ticket in-progress")
-    @option("ticket_id", description="ticket ID")
-    async def progress(self, ctx: discord.ApplicationContext, ticket_id:int):
-        """Update status on a ticket, using: unassign, resolve, progress"""
+    @option("ticket_id", description="ticket ID", autocomplete=basic_autocomplete(default_ticket))
+    async def progress(self, ctx: discord.ApplicationContext, ticket_id:int, member:discord.Member=None):
+        """Update status on a ticket, using: progress"""
         # lookup the user
-        user = self.redmine.user_mgr.find(ctx.user.name)
+        user_name = ctx.user.name
+        if member:
+            if self.bot.is_admin(ctx.user):
+                log.info(f"ADMIN: {ctx.user.name} invoked progress on behalf of {member.name}")
+                user_name = member.name
+        user = self.redmine.user_mgr.find(user_name)
         if not user:
-            await ctx.respond(f"User {ctx.user.name} not mapped to redmine. Use `/scn add` to create the mapping.") # error
+            await ctx.respond(f"User {ctx.user.name} not mapped to redmine. Use `/scn add [redmine-user]` to create the mapping.")
             return
 
-        ticket = self.redmine.get_ticket(ticket_id)
+        ticket = self.redmine.ticket_mgr.get(ticket_id)
         if ticket:
             updated = self.redmine.progress_ticket(ticket_id, user.login)
             ticket_link = self.bot.formatter.format_link(ticket)
@@ -396,18 +409,23 @@ class TicketsCog(commands.Cog):
 
 
     @ticket.command(description="Assign a ticket")
-    @option("ticket_id", description="ticket ID")
-    async def assign(self, ctx: discord.ApplicationContext, ticket_id:int):
+    @option("ticket_id", description="ticket ID", autocomplete=basic_autocomplete(default_ticket))
+    async def assign(self, ctx: discord.ApplicationContext, ticket_id:int, member:discord.Member=None):
         # lookup the user
-        user = self.redmine.user_mgr.find(ctx.user.name)
+        user_name = ctx.user.name
+        if member:
+            if self.bot.is_admin(ctx.user):
+                log.info(f"ADMIN: {ctx.user.name} invoked assign on behalf of {member.name}")
+                user_name = member.name
+        user = self.redmine.user_mgr.find(user_name)
         if not user:
-            await ctx.respond(f"User {ctx.user.name} not mapped to redmine. Use `/scn add` to create the mapping.") # error
+            await ctx.respond(f"User {ctx.user.name} not mapped to redmine. Use `/scn add [redmine-user]` to create the mapping.")
             return
 
-        ticket = self.redmine.get_ticket(ticket_id)
+        ticket = self.redmine.ticket_mgr.get(ticket_id)
         if ticket:
             self.redmine.assign_ticket(ticket_id, user.login)
-            await self.bot.formatter.print_ticket(self.redmine.get_ticket(ticket_id), ctx)
+            await self.bot.formatter.print_ticket(self.redmine.ticket_mgr.get(ticket_id), ctx)
         else:
             await ctx.respond(f"Ticket {ticket_id} not found.") # print error
 
@@ -487,13 +505,9 @@ class TicketsCog(commands.Cog):
 
 
     @ticket.command(name="alert", description="Alert collaborators on a ticket")
-    @option("ticket_id", description="ID of ticket to alert")
-    async def alert_ticket(self, ctx: discord.ApplicationContext, ticket_id:int=0):
-        if not ticket_id:
-            # check thread for ticket id
-            ticket_id = self.bot.parse_thread_title(ctx.channel.name)
-
-        ticket = self.redmine.get_ticket(ticket_id, include="watchers") # inclde the option watchers/collaborators field
+    @option("ticket_id", description="ID of ticket to alert", autocomplete=basic_autocomplete(default_ticket))
+    async def alert_ticket(self, ctx: discord.ApplicationContext, ticket_id:int):
+        ticket = self.redmine.ticket_mgr.get(ticket_id, include="watchers") # inclde the option watchers/collaborators field
         if ticket:
             # * notify owner and collaborators of *notable* (not all) status changes of a ticket
             # * user @reference for notify
@@ -515,7 +529,7 @@ class TicketsCog(commands.Cog):
     @ticket.command(description="Thread a Redmine ticket in Discord")
     @option("ticket_id", description="ID of tick to create thread for")
     async def thread(self, ctx: discord.ApplicationContext, ticket_id:int):
-        ticket = self.redmine.get_ticket(ticket_id)
+        ticket = self.redmine.ticket_mgr.get(ticket_id)
         if ticket:
             ticket_link = self.bot.formatter.format_link(ticket)
 
@@ -547,11 +561,11 @@ class TicketsCog(commands.Cog):
 
 
     @ticket.command(name="tracker", description="Update the tracker of a ticket")
-    @option("ticket_id", description="ID of ticket to update")
+    @option("ticket_id", description="ID of ticket to update", autocomplete=basic_autocomplete(default_ticket))
     @option("tracker", description="Track to assign to ticket", autocomplete=get_trackers)
     async def tracker(self, ctx: discord.ApplicationContext, ticket_id:int, tracker:str):
         user = self.redmine.user_mgr.find_discord_user(ctx.user.name)
-        ticket = self.redmine.get_ticket(ticket_id)
+        ticket = self.redmine.ticket_mgr.get(ticket_id)
         if ticket:
             ticket_link = self.bot.formatter.format_link(ticket)
 
@@ -570,11 +584,11 @@ class TicketsCog(commands.Cog):
 
 
     @ticket.command(name="priority", description="Update the tracker of a ticket")
-    @option("ticket_id", description="ID of ticket to update")
+    @option("ticket_id", description="ID of ticket to update", autocomplete=basic_autocomplete(default_ticket))
     @option("priority", description="Priority to assign to ticket", autocomplete=get_priorities)
     async def priority(self, ctx: discord.ApplicationContext, ticket_id:int, priority_str:str):
         user = self.redmine.user_mgr.find_discord_user(ctx.user.name)
-        ticket = self.redmine.get_ticket(ticket_id)
+        ticket = self.redmine.ticket_mgr.get(ticket_id)
         if ticket:
             # look up the priority
             priority = self.bot.lookup_priority(priority_str)
@@ -597,7 +611,7 @@ class TicketsCog(commands.Cog):
 
 
     @ticket.command(name="subject", description="Update the subject of a ticket")
-    @option("ticket_id", description="ID of ticket to update")
+    @option("ticket_id", description="ID of ticket to update", autocomplete=basic_autocomplete(default_ticket))
     @option("subject", description="Updated subject")
     async def subject(self, ctx: discord.ApplicationContext, ticket_id:int, subject:str):
         user = self.redmine.user_mgr.find_discord_user(ctx.user.name)
@@ -605,7 +619,7 @@ class TicketsCog(commands.Cog):
             await ctx.respond(f"ERROR: Discord user without redmine config: {ctx.user.name}. Create with `/scn add`")
             return
 
-        ticket = self.redmine.get_ticket(ticket_id)
+        ticket = self.redmine.ticket_mgr.get(ticket_id)
         if not ticket:
             await ctx.respond(f"ERROR: Unkown ticket ID: {ticket_id}")
             return
@@ -619,6 +633,7 @@ class TicketsCog(commands.Cog):
         await ctx.respond(
             f"Updated subject of {ticket_link} to: {updated.subject}",
             embed=self.bot.formatter.ticket_embed(ctx, updated))
+
 
     @ticket.command(name="help", description="Display hepl about ticket management")
     async def help(self, ctx: discord.ApplicationContext):

--- a/netbot/netbot.py
+++ b/netbot/netbot.py
@@ -106,7 +106,6 @@ class NetBot(commands.Bot):
 
         super().run(os.getenv('DISCORD_TOKEN'))
 
-
     async def on_ready(self):
         #log.info(f"Logged in as {self.user} (ID: {self.user.id})")
         #log.debug(f"bot: {self}, guilds: {self.guilds}")
@@ -269,7 +268,7 @@ class NetBot(commands.Bot):
         # get the ticket id from the thread name
         ticket_id = self.parse_thread_title(thread.name)
 
-        ticket = self.redmine.get_ticket(ticket_id, include="journals")
+        ticket = self.redmine.ticket_mgr.get(ticket_id, include="journals")
         if ticket:
             completed = await self.synchronize_ticket(ticket, thread)
             # note: synchronize_ticket returns True only when successfully completing a sync
@@ -439,6 +438,17 @@ class NetBot(commands.Bot):
                 log.info(f"ERROR: user ID {named} not found")
 
         return []
+
+
+    def is_admin(self, user: discord.Member) -> bool:
+        """Check if the given Discord memeber is in a authorized role"""
+        # search user for "auth" role
+        for role in user.roles:
+            if "auth" == role.name: ## FIXME
+                return True
+
+        # auth role not found
+        return False
 
 
 def main():

--- a/netbot/netbot.py
+++ b/netbot/netbot.py
@@ -49,6 +49,17 @@ TEAM_MAPPING = {
     "uw-research-nsf": "research-team",
 }
 
+# utility method to get a list of (one) ticket from the title of the channel, or empty list
+# TODO could be moved to NetBot
+def default_ticket(ctx: discord.AutocompleteContext) -> list[int]:
+    # examine the thread
+    ticket_id = ctx.bot.parse_thread_title(ctx.interaction.channel.name)
+    if ticket_id:
+        return [ticket_id]
+    else:
+        return []
+
+
 class NetbotException(Exception):
     """netbot exception"""
 

--- a/redmine/redmine.py
+++ b/redmine/redmine.py
@@ -103,28 +103,17 @@ class Client():
         self.ticket_mgr.upload_attachments(user, attachments)
 
 
-    def get_tickets_by(self, user) -> list[Ticket]:
-        return self.ticket_mgr.get_tickets_by(user)
-
-
-    def get_ticket(self, ticket_id:int, **params) -> Ticket:
-        return self.ticket_mgr.get(ticket_id, **params)
-
-
     def find_ticket_from_str(self, string:str) -> Ticket:
         """parse a ticket number from a string and get the associated ticket"""
         # for now, this is a trivial REGEX to match '#nnn' in a string, and return ticket #nnn
         match = re.search(r'#(\d+)', string)
         if match:
             ticket_num = int(match.group(1))
-            return self.get_ticket(ticket_num)
+            return self.ticket_mgr.get(ticket_num)
         else:
             log.debug(f"Unable to match ticket number in: {string}")
             return []
 
-
-    def remove_ticket(self, ticket_id:int):
-        self.ticket_mgr.remove(ticket_id)
 
     def most_recent_ticket_for(self, email: str) -> Ticket:
         return self.ticket_mgr.most_recent_ticket_for(email)
@@ -167,12 +156,6 @@ class Client():
 
     def reject_ticket(self, ticket_id, user_id=None):
         self.ticket_mgr.reject_ticket(ticket_id, user_id)
-
-    def unassign_ticket(self, ticket_id, user_id=None):
-        self.ticket_mgr.unassign_ticket(ticket_id, user_id)
-
-    def resolve_ticket(self, ticket_id, user_id=None) -> Ticket:
-        return self.ticket_mgr.resolve_ticket(ticket_id, user_id)
 
     def get_team(self, teamname:str) -> Team:
         return self.user_mgr.cache.get_team_by_name(teamname)

--- a/redmine/tickets.py
+++ b/redmine/tickets.py
@@ -185,7 +185,7 @@ class TicketManager():
             a.set_token(token)
 
 
-    def get_tickets_by(self, user) -> list[Ticket]:
+    def get_by(self, user) -> list[Ticket]:
         # GET /issues.json?author_id=6
         response = self.session.get(f"/issues.json?author_id={user.id}")
         if response:
@@ -517,7 +517,7 @@ class TicketManager():
         return self.update(ticket_id, fields, user_id)
 
 
-    def unassign_ticket(self, ticket_id, user_id=None):
+    def unassign(self, ticket_id, user_id=None):
         fields = {
             "assigned_to_id": "",
             "status_id": "1", # New, TODO lookup in status table
@@ -525,7 +525,7 @@ class TicketManager():
         self.update(ticket_id, fields, user_id)
 
 
-    def resolve_ticket(self, ticket_id, user_id=None):
+    def resolve(self, ticket_id, user_id=None):
         return self.update(ticket_id, {"status_id": "3"}, user_id) # '3' is the status_id, it doesn't accept "Resolved"
 
 

--- a/tests/test_cog_scn.py
+++ b/tests/test_cog_scn.py
@@ -120,7 +120,7 @@ class TestSCNCog(test_utils.BotTestCase):
         # check for actual changes! updated timestamp!
 
         # cleanup
-        self.redmine.remove_ticket(ticket.id)
+        self.redmine.ticket_mgr.remove(ticket.id)
 
 
     async def test_block_user(self):
@@ -135,11 +135,11 @@ class TestSCNCog(test_utils.BotTestCase):
             self.assertTrue(self.redmine.user_mgr.is_blocked(self.user))
 
             # confirm ticket rejected
-            check_ticket = self.redmine.get_ticket(ticket.id)
+            check_ticket = self.redmine.ticket_mgr.get(ticket.id)
             self.assertEqual("Reject", check_ticket.status.name)
         finally:
             # cleanup
-            self.redmine.remove_ticket(ticket.id)
+            self.redmine.ticket_mgr.remove(ticket.id)
 
 
     async def test_unblock_user(self):
@@ -204,7 +204,7 @@ class TestSCNCog(test_utils.BotTestCase):
 
         # clean up
         del self.bot.ticket_locks[ticket.id]
-        self.redmine.remove_ticket(ticket.id)
+        self.redmine.ticket_mgr.remove(ticket.id)
 
 
 if __name__ == '__main__':

--- a/tests/test_cog_tickets.py
+++ b/tests/test_cog_tickets.py
@@ -94,9 +94,9 @@ class TestTicketsCog(test_utils.BotTestCase):
         self.assertIn(test_title, response_str)
 
         # delete ticket with redmine api, assert
-        self.redmine.remove_ticket(int(ticket_id))
+        self.redmine.ticket_mgr.remove(int(ticket_id))
         # check that the ticket has been removed
-        self.assertIsNone(self.redmine.get_ticket(int(ticket_id)))
+        self.assertIsNone(self.redmine.ticket_mgr.get(int(ticket_id)))
 
     @unittest.skip
     async def test_ticket_unassign(self):
@@ -109,8 +109,8 @@ class TestTicketsCog(test_utils.BotTestCase):
         self.assertIn(str(ticket.id), response_str)
 
         # delete ticket with redmine api, assert
-        self.redmine.remove_ticket(int(ticket.id))
-        self.assertIsNone(self.redmine.get_ticket(int(ticket.id)))
+        self.redmine.ticket_mgr.remove(int(ticket.id))
+        self.assertIsNone(self.redmine.ticket_mgr.get(int(ticket.id)))
 
 
     @unittest.skip
@@ -124,8 +124,8 @@ class TestTicketsCog(test_utils.BotTestCase):
         self.assertIn(str(ticket.id), response_str)
 
         # delete ticket with redmine api, assert
-        self.redmine.remove_ticket(ticket.id)
-        self.assertIsNone(self.redmine.get_ticket(int(ticket.id)))
+        self.redmine.ticket_mgr.remove(ticket.id)
+        self.assertIsNone(self.redmine.ticket_mgr.get(int(ticket.id)))
 
     # create thread/sync
     async def test_thread_sync(self):
@@ -155,7 +155,7 @@ class TestTicketsCog(test_utils.BotTestCase):
         self.assertIn(ticket.subject, thread_response)
 
         # delete the ticket
-        self.redmine.remove_ticket(ticket.id)
+        self.redmine.ticket_mgr.remove(ticket.id)
 
 
     async def test_query_term(self):
@@ -180,7 +180,7 @@ class TestTicketsCog(test_utils.BotTestCase):
         #self.assertEqual(ticket.id, result_4[0].id)
 
         # delete the ticket
-        self.redmine.remove_ticket(ticket.id)
+        self.redmine.ticket_mgr.remove(ticket.id)
 
 
     async def test_resolve_invalid_discord_user(self):

--- a/tests/test_imap.py
+++ b/tests/test_imap.py
@@ -122,7 +122,7 @@ class TestMessages(test_utils.RedmineTestCase):
         self.assertEqual(user.id, tickets[0].author.id)
 
         # remove the ticket
-        self.redmine.remove_ticket(tickets[0].id)
+        self.redmine.ticket_mgr.remove(tickets[0].id)
 
         # remove the user after the test
         self.redmine.user_mgr.remove(user)
@@ -151,7 +151,7 @@ class TestMessages(test_utils.RedmineTestCase):
         self.assertEqual(ticket.id, tickets[0].id)
 
         # clean up
-        self.redmine.remove_ticket(ticket.id)
+        self.redmine.ticket_mgr.remove(ticket.id)
 
 
     def test_handle_message(self):
@@ -169,7 +169,7 @@ class TestMessages(test_utils.RedmineTestCase):
         self.assertEqual(subject, tickets[0].subject)
 
         # clean up
-        self.redmine.remove_ticket(tickets[0].id)
+        self.redmine.ticket_mgr.remove(tickets[0].id)
 
 
     def test_to_cc(self):
@@ -194,7 +194,7 @@ class TestMessages(test_utils.RedmineTestCase):
         self.assertEqual(cc_addr, ticket.cc[0])
 
         # clean up
-        self.redmine.remove_ticket(tickets[0].id)
+        self.redmine.ticket_mgr.remove(tickets[0].id)
 
 
 if __name__ == '__main__':

--- a/tests/test_netbot.py
+++ b/tests/test_netbot.py
@@ -65,11 +65,11 @@ class TestNetbot(test_utils.BotTestCase):
         self.assertIn(body, thread.send.call_args.args[0])
 
         # get notes from redmine, assert tags in most recent
-        check_ticket = self.redmine.get_ticket(ticket.id, include="journals") # get the notes
+        check_ticket = self.redmine.ticket_mgr.get(ticket.id, include="journals") # get the notes
         self.assertIsNotNone(check_ticket)
         #self.assertIn(body, ticket.journals[-1].notes) NOT until thread history is working
 
-        self.redmine.remove_ticket(ticket.id)
+        self.redmine.ticket_mgr.remove(ticket.id)
 
 
     async def test_sync_ticket_long_message(self):
@@ -97,7 +97,7 @@ class TestNetbot(test_utils.BotTestCase):
         self.assertLessEqual(len(thread.send.call_args.args[0]), MAX_MESSAGE_LEN, "Message sent to Discord is too long")
 
         # clean up
-        self.redmine.remove_ticket(ticket.id)
+        self.redmine.ticket_mgr.remove(ticket.id)
 
 
     async def test_on_application_command_error(self):

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -73,7 +73,7 @@ class TestRedmine(test_utils.RedmineTestCase):
         self.assertEqual(ticket.id, tickets[0].id)
 
         # clean up
-        self.redmine.remove_ticket(ticket.id)
+        self.redmine.ticket_mgr.remove(ticket.id)
 
 
 if __name__ == '__main__':

--- a/tests/test_synctime.py
+++ b/tests/test_synctime.py
@@ -32,14 +32,14 @@ class TestTime(test_utils.RedmineTestCase):
         self.redmine.ticket_mgr.update_sync_record(sync_rec)
 
         # refetch ticket
-        ticket2 = self.redmine.get_ticket(ticket.id)
+        ticket2 = self.redmine.ticket_mgr.get(ticket.id)
         sync_rec2 = ticket2.validate_sync_record(expected_channel=1111) # NOT the test_channel
         log.info(f"ticket2 updated={ticket2.updated_on}, {synctime.age_str(ticket2.updated_on)} ago, channel: {sync_rec.channel_id}")
 
         self.assertIsNone(sync_rec2)
 
         # clean up
-        self.redmine.remove_ticket(ticket.id)
+        self.redmine.ticket_mgr.remove(ticket.id)
 
 
     def test_redmine_isoformat(self):

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -106,15 +106,15 @@ class TestIntegrationTicketManager(test_utils.RedmineTestCase):
         ticket = self.create_test_ticket()
 
         # unassign the ticket
-        self.tickets_mgr.unassign_ticket(ticket.id)
+        self.tickets_mgr.unassign(ticket.id)
 
         check = self.tickets_mgr.get(ticket.id)
         self.assertEqual("New", check.status.name)
         self.assertEqual("", check.assigned)
 
         # delete ticket with redmine api, assert
-        self.redmine.remove_ticket(int(ticket.id))
-        self.assertIsNone(self.redmine.get_ticket(int(ticket.id)))
+        self.redmine.ticket_mgr.remove(int(ticket.id))
+        self.assertIsNone(self.redmine.ticket_mgr.get(int(ticket.id)))
 
 
     def test_ticket_collaborate(self):
@@ -128,8 +128,8 @@ class TestIntegrationTicketManager(test_utils.RedmineTestCase):
         self.assertEqual(self.user.id, check.watchers[0].id)
 
         # delete ticket with redmine api, assert
-        self.redmine.remove_ticket(int(ticket.id))
-        self.assertIsNone(self.redmine.get_ticket(int(ticket.id)))
+        self.redmine.ticket_mgr.remove(int(ticket.id))
+        self.assertIsNone(self.redmine.ticket_mgr.get(int(ticket.id)))
 
 
 


### PR DESCRIPTION
Added admin-specific params to allow member assignement for:
* collaborate
* progress
* assign

Adding ticket ID autofill if in ticket thread:
* collaborate
* progress
* assign
* unassign
* resolve
* tracker
* priority
* subject