### PR TITLE
bug fix: handle if `resp` is None

### DIFF
--- a/redmine/tickets.py
+++ b/redmine/tickets.py
@@ -116,9 +116,10 @@ class TicketManager():
         priorities: dict[str,NamedId] = {}
 
         resp = self.session.get("/enumerations/issue_priorities.json")
-        for priority in reversed(resp['issue_priorities']):
-            if priority.get('active', False):
-                priorities[priority['name']] = NamedId(priority['id'], priority['name'])
+        if resp:
+            for priority in reversed(resp['issue_priorities']):
+                if priority.get('active', False):
+                    priorities[priority['name']] = NamedId(priority['id'], priority['name'])
 
         return priorities
 


### PR DESCRIPTION
Handle if resp is None in `load_priorities`. I saw this take down netbot earlier today